### PR TITLE
feat: v6 cascade fixes (理論チェーン化・表示精度・プレゼン/アブセン)

### DIFF
--- a/backend/app/routers/cascade.py
+++ b/backend/app/routers/cascade.py
@@ -120,19 +120,21 @@ def _format_value(node: KpiResult) -> str:
     if unit == "スコア":
         return f"{val:.2f}"
     if unit == "名":
-        return f"{int(val):,}名"
+        return f"{val:,.0f}名"
     if unit == "件":
-        return f"{int(val)}件"
+        return f"{val:.1f}件"
     if unit == "万kW":
         return f"{val:.1f}万kW"
     if unit == "万t":
         return f"{val:.1f}万t"
     if unit == "千円/戸":
-        return f"{int(val)}千円/戸"
+        return f"{val:.1f}千円/戸"
     if unit == "年連続":
-        return f"{int(val)}年連続"
+        return f"{val:.1f}年連続"
     if unit == "指数":
-        return f"{int(val)}指数"
+        return f"{val:.1f}指数"
+    if unit == "日":
+        return f"{val:.2f}日"
     return f"{val}"
 
 
@@ -230,7 +232,7 @@ def _financial_to_cards(
             projected=ROIC_CURRENT + result.roic_delta,
             improvement=result.roic_delta,
             reliability="★",
-            description="参考値（フル効果時）",
+            description="人的資本単独寄与（ACT2027 目標 +0.2pt の一部）",
             unit="%",
         )
     )
@@ -252,7 +254,7 @@ def _financial_to_cards(
             projected=ROE_CURRENT + result.roe_delta,
             improvement=result.roe_delta,
             reliability="★",
-            description="参考値（フル効果時）",
+            description="人的資本単独寄与（ACT2027 目標 +1.7pt の一部）",
             unit="%",
         )
     )

--- a/backend/app/services/calculator.py
+++ b/backend/app/services/calculator.py
@@ -25,17 +25,27 @@ OP_INCOME_M = 10_593
 TAX_RATE = 0.325
 EQUITY_M = 85_909
 DEBT_M = 196_967
+NET_INCOME_M = 5_400  # 純利益（FY2025 実績）
 
 NOPAT_M = OP_INCOME_M * (1 - TAX_RATE)
 INVESTED_CAP = EQUITY_M + DEBT_M
-ROIC_CURRENT = NOPAT_M / INVESTED_CAP
-ROE_CURRENT = NOPAT_M / EQUITY_M
-LEVERAGE = INVESTED_CAP / EQUITY_M
 
-ROIC_TARGET_2027 = 0.023
-ROE_TARGET_2027 = 0.080
+# ROIC: NOPAT / 投下資本（標準定義）
+ROIC_CURRENT = NOPAT_M / INVESTED_CAP   # ≒ 2.53%
 
-# v5: 売上効果メイン目標
+# ROE: Net Income / Equity（標準定義、NOPAT ではない）
+ROE_CURRENT = NET_INCOME_M / EQUITY_M   # ≒ 6.3%
+
+LEVERAGE = INVESTED_CAP / EQUITY_M       # ≒ 3.29
+
+# ACT2027 公式目標
+ROIC_TARGET_2027 = 0.023  # 2.3%
+ROE_TARGET_2027 = 0.080   # 8.0%
+
+# 営業利益率（売上→NOPAT 換算用）
+OP_MARGIN = OP_INCOME_M / REVENUE_M     # ≒ 4.16%
+
+# 売上効果メイン目標
 SALES_TARGET_M = 600
 SALES_TARGET_OKU = 6.0
 
@@ -105,16 +115,33 @@ LAYER3_META: dict[str, tuple[Any, ...]] = {
 # 中間層メタ情報
 # ════════════════════════════════════════════════════════════
 MID_META: dict[str, tuple[Any, ...]] = {
-    # サーベイ由来9個
+    # サーベイ由来10個（v6: poc を region に統合し、プレゼン/アブセンを追加）
     "safety_zero": ("保安事故ゼロ継続", "件", 0, 0, ["all", "safety"], "★★", "重大事故ゼロ継続"),
-    "poc": ("共創PoC件数", "件", 10, 15, ["all", "challenge"], "★★", "TOMOSHIBI連動"),
     "co2": ("CO2削減貢献量", "万t", 60, 87, ["all"], "★", "Scope 1+2"),
     "jcsi": ("JCSI", "年連続", 4, 5, ["all"], "★★★", "Fornell 2006"),
     "ltv": ("顧客LTV", "千円/戸", 240, 280, ["all"], "★★★", "Gupta&Lehmann"),
-    "region": ("地域共創力", "件", 10, 15, ["all"], "★★★", "Ikuta&Fujii 2025"),
+    "region": ("地域共創力", "件", 10, 15, ["all"], "★★★", "Ikuta&Fujii 2025（PoC を統合）"),
     "esg": ("ESG評価", "指数", 3, 5, ["all"], "★★★", "Wilberg 2025"),
     "recruit": ("採用・定着力", "%", 95.8, 98.0, ["all", "safety"], "★★", "Li et al.2022"),
     "safety_brand": ("保安ブランド", "件", 0, 0, ["all", "safety"], "★★★", "柳・今野2024"),
+    "presenteeism": (
+        "プレゼンティーイズム",
+        "%",
+        80.0,
+        85.0,
+        ["all", "safety"],
+        "★★",
+        "発揮度。経産省・SAP事例",
+    ),
+    "absenteeism": (
+        "アブセンティーイズム",
+        "日",
+        1.70,
+        1.50,
+        ["all", "safety"],
+        "★★",
+        "年間欠勤日数。ISO30414準拠",
+    ),
     # 実カウント型（v5: 仮係数で計算するが、図では「点線関連」として表現）
     "dx_core": ("DXコア人財数", "名", 200, 650, ["all", "challenge"], "★★", "ACT2027目標"),
     "reskill": ("リスキル実践者数", "名", 43, 2000, ["all", "challenge"], "★", "ACT2027目標"),
@@ -127,9 +154,6 @@ MID_META: dict[str, tuple[Any, ...]] = {
 LAYER3_TO_MID: list[tuple[str, str, float, str, str]] = [
     ("eng", "safety_zero", 0.30, "★★", "Gallup 2020"),
     ("retention", "safety_zero", 0.10, "★", "仮置き"),
-    ("eng", "poc", 0.10, "★", "仮置き"),
-    ("challenge", "poc", 0.20, "★", "仮置き"),
-    ("transform", "poc", 0.25, "★", "仮置き"),
     ("transform", "co2", 0.15, "★", "仮置き"),
     ("eng", "jcsi", 0.08, "★★★", "Gallup × Fornell"),
     ("retention", "jcsi", 0.08, "★★★", "Park&Shaw × Fornell"),
@@ -144,6 +168,12 @@ LAYER3_TO_MID: list[tuple[str, str, float, str, str]] = [
     ("retention", "recruit", 0.30, "★★★", "Li et al.2022"),
     ("eng", "safety_brand", 0.12, "★★★", "Gallup × 柳・今野"),
     ("retention", "safety_brand", 0.04, "★", "仮置き"),
+    # v6: プレゼンティーイズム経路（ENG・定着が主因）
+    ("eng", "presenteeism", 0.20, "★★", "Gallup × SAP事例（健康文化指数→営業利益）"),
+    ("retention", "presenteeism", 0.10, "★", "仮置き"),
+    # v6: アブセンティーイズム経路（定着率が主因）
+    ("retention", "absenteeism", 0.30, "★★", "ISO30414準拠"),
+    ("eng", "absenteeism", 0.10, "★", "仮置き"),
 ]
 
 # 3層→実カウント（点線関連、係数は仮置き）
@@ -160,22 +190,25 @@ LAYER3_TO_MID_COUNT: list[tuple[str, str, float, str, str]] = [
 # ════════════════════════════════════════════════════════════
 MID_TO_FIN: dict[str, tuple[float, float, float]] = {
     "safety_zero": (0.015, 0.012, 0.074),
-    "poc": (0.036, 0.008, 0.028),
     "renewable_mid": (0.035, 0.015, 0.075),
     "co2": (0.009, 0.004, 0.058),
     "jcsi": (0.035, 0.025, 0.025),
     "ltv": (0.030, 0.010, 0.040),
-    "region": (0.063, 0.014, 0.049),
+    # v6: PoC を統合した分、地域共創力の重みを微増
+    "region": (0.080, 0.020, 0.060),
     "esg": (0.230, 0.100, 0.130),
     "recruit": (0.060, 0.120, 0.140),
     "safety_brand": (0.020, 0.030, 0.120),
+    # v6: プレゼンティーイズム — 3,500人 × 75万損失/年 = 26億/年 → 5%改善で 1.3億/年（売上換算 0.5%）
+    "presenteeism": (0.030, 0.080, 0.000),
+    # v6: アブセンティーイズム — 欠勤・代替要員費の直接削減
+    "absenteeism": (0.005, 0.040, 0.000),
     "dx_core": (0.020, 0.040, 0.030),
     "reskill": (0.040, 0.070, 0.050),
 }
 
 FIN_RELIABILITY: dict[str, str] = {
     "safety_zero": "★★",
-    "poc": "★",
     "renewable_mid": "★★★",
     "co2": "★",
     "jcsi": "★★★",
@@ -184,6 +217,8 @@ FIN_RELIABILITY: dict[str, str] = {
     "esg": "★★★",
     "recruit": "★★★",
     "safety_brand": "★★★",
+    "presenteeism": "★★",
+    "absenteeism": "★★",
     "dx_core": "★",
     "reskill": "★",
 }
@@ -194,9 +229,8 @@ FIN_RELIABILITY: dict[str, str] = {
 # v5：日常重視配分で 6,000P → 売上+6億円
 SALES_CALIBRATION = 0.01815
 
-# 参考値（ROIC/ROE）
-ROE_CALIBRATION = 0.024
-ROIC_CALIBRATION = ROE_CALIBRATION / LEVERAGE
+# v6: ROIC/ROE は売上効果から OP_MARGIN × (1-TAX_RATE) で NOPAT に換算し、
+#      投下資本/自己資本で除して理論的に求める。proxy 係数は撤廃。
 
 
 # ════════════════════════════════════════════════════════════
@@ -318,10 +352,9 @@ def _calc_layer3(points: PointsInput) -> dict[str, KpiResult]:
 def _calc_mid(layer3: dict[str, KpiResult]) -> dict[str, KpiResult]:
     """3層 × LAYER3_TO_MID = 中間層13個（達成率）"""
     boosts = {}
-    # サーベイ由来9個
+    # サーベイ由来10個（v6: poc を region に統合し、プレゼン/アブセンを追加）
     survey_ids = {
         "safety_zero",
-        "poc",
         "co2",
         "jcsi",
         "ltv",
@@ -329,6 +362,8 @@ def _calc_mid(layer3: dict[str, KpiResult]) -> dict[str, KpiResult]:
         "esg",
         "recruit",
         "safety_brand",
+        "presenteeism",
+        "absenteeism",
     }
     for mid_id in survey_ids:
         boosts[mid_id] = 0.0
@@ -359,7 +394,7 @@ def _calc_mid(layer3: dict[str, KpiResult]) -> dict[str, KpiResult]:
 def _calc_financial(
     mid: dict[str, KpiResult],
 ) -> tuple[dict[str, float], float, float, float, float]:
-    """中間層 → 財務ドライバー → 売上効果 + ROIC/ROE"""
+    """中間層 → 売上効果 → NOPAT → ΔROIC/ΔROE（v6: 理論チェーン）"""
     revenue = cost = capital = 0.0
     for mid_id, node in mid.items():
         if mid_id not in MID_TO_FIN:
@@ -371,14 +406,15 @@ def _calc_financial(
 
     drivers = {"revenue": revenue, "cost": cost, "capital": capital}
 
-    # メイン：売上効果
+    # メイン：売上効果（既存ロジック維持）
     sales_effect_m = revenue * REVENUE_M * SALES_CALIBRATION
     sales_effect_oku = sales_effect_m / 100
 
-    # 参考：ROIC/ROE
-    fin_total = revenue + cost + capital
-    roic_delta = fin_total * ROIC_CALIBRATION
-    roe_delta = roic_delta * LEVERAGE
+    # v6: ROIC/ROE は売上効果から理論的に導出
+    # 売上 → 営業利益 → NOPAT → ΔROIC/ΔROE
+    nopat_increase_m = sales_effect_m * OP_MARGIN * (1 - TAX_RATE)
+    roic_delta = nopat_increase_m / INVESTED_CAP
+    roe_delta = nopat_increase_m / EQUITY_M
 
     return drivers, sales_effect_m, sales_effect_oku, roic_delta, roe_delta
 
@@ -453,24 +489,24 @@ def _build_connections() -> list[Edge]:
             citation="売上キャリブ（仮置き）",
         )
     )
-    # 参考：財務ドライバー → ROIC/ROE
-    for driver in ("revenue", "cost", "capital"):
-        edges.append(
-            Edge(
-                from_id=driver,
-                to_id="roic",
-                coefficient=ROIC_CALIBRATION,
-                reliability="★",
-                citation="ROICキャリブ（参考）",
-            )
+    # v6: 売上効果 → ROIC（NOPAT/投下資本で理論的に算出）
+    edges.append(
+        Edge(
+            from_id="sales_effect",
+            to_id="roic",
+            coefficient=OP_MARGIN * (1 - TAX_RATE) / INVESTED_CAP * REVENUE_M,
+            reliability="★★★",
+            citation="ΔROIC = ΔSales × OP_MARGIN × (1-TaxRate) / 投下資本",
         )
+    )
+    # v6: ROIC → ROE は概念的に残すが、式の上では使ってない（NOPAT/Equity で直接計算）
     edges.append(
         Edge(
             from_id="roic",
             to_id="roe",
             coefficient=LEVERAGE,
             reliability="★★★",
-            citation="レバレッジ（FY2025）",
+            citation="参考：ROE = ROIC × レバレッジの関係（v6 では NOPAT/Equity で直接計算）",
         )
     )
     return edges

--- a/frontend/src/components/cascade/CascadeBoard.tsx
+++ b/frontend/src/components/cascade/CascadeBoard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { simulateCascade } from "@/lib/cascade/client";
@@ -31,12 +30,15 @@ import { IndicatorDetailModal } from "./IndicatorDetailModal";
 import { InputGrid } from "./InputGrid";
 import { PlaceholderCard } from "./PlaceholderCard";
 
-const TABS = [
-  { key: "all", label: "すべて" },
-  { key: "challenge", label: "挑戦の指標" },
-  { key: "safety", label: "安心・安全" },
+// スコープトグル（全社 / 自部署）。タブによる指標フィルタは廃止。
+const SCOPE_OPTIONS = [
+  { key: "company", label: "全社" },
+  { key: "department", label: "自部署" },
 ] as const;
-type TabKey = (typeof TABS)[number]["key"];
+type ScopeKey = (typeof SCOPE_OPTIONS)[number]["key"];
+
+// TODO: ユーザー API（/api/me 等）から取得する想定。デモ用にハードコード。
+const USER_DEPT_LABEL = "営業本部・福岡リビング営業部";
 
 const HUDO_LABEL_DEFAULT: Record<string, string> = {
   sales_effect: "売上効果",
@@ -87,7 +89,7 @@ function CascadeBoardInner() {
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
-  const [tab, setTab] = useState<TabKey>("all");
+  const [scope, setScope] = useState<ScopeKey>("company");
   const [detailId, setDetailId] = useState<string | null>(null);
 
   // ホバー > クリック の優先度で「現在の焦点」を決める
@@ -234,18 +236,6 @@ function CascadeBoardInner() {
     );
   };
 
-  // タブに合ったカードのみ表示するフィルタ
-  const visibleByTab = useCallback(
-    (calcId: string): boolean => {
-      if (tab === "all") return true;
-      const c = cardByCalcId.get(calcId);
-      // CardData.tab_key は単一文字列だが、calculator.py では tabs に複数候補がある。
-      // ここでは tab_key を含む（または all を含む）で判定する素朴なルール。
-      return c?.tab_key === tab || c?.tab_key === "all";
-    },
-    [tab, cardByCalcId],
-  );
-
   const cardOf = (id: string): CardData | undefined => cardByCalcId.get(id);
 
   const total = data?.points_total ?? 0;
@@ -267,25 +257,25 @@ function CascadeBoardInner() {
 
   return (
     <div className="flex flex-col gap-2">
-      {/* ヘッダー + タブ + サマリー（1行に圧縮） */}
+      {/* ヘッダー + スコープトグル + サマリー（1行に圧縮） */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-ink-secondary/20 pb-1.5">
         <h1 className="text-[18px] font-semibold tracking-tight text-ink-primary">
           因果ストーリー
         </h1>
         <div className="flex gap-4 text-[13px]">
-          {TABS.map((t) => (
+          {SCOPE_OPTIONS.map((s) => (
             <button
-              key={t.key}
+              key={s.key}
               type="button"
-              onClick={() => setTab(t.key)}
+              onClick={() => setScope(s.key)}
               className={cn(
                 "-mb-1.5 border-b-2 pb-1.5 transition-colors",
-                tab === t.key
+                scope === s.key
                   ? "border-brand-primary font-semibold text-ink-primary"
                   : "border-transparent text-ink-secondary hover:text-ink-primary",
               )}
             >
-              {t.label}
+              {s.key === "department" ? USER_DEPT_LABEL : s.label}
             </button>
           ))}
         </div>
@@ -324,25 +314,6 @@ function CascadeBoardInner() {
         {error ? (
           <span className="w-full text-[11px] text-status-ng-fg">⚠ {error}</span>
         ) : null}
-      </div>
-
-      {/* 逆算ロジック説明 */}
-      <div className="flex items-start gap-1.5 rounded-md border-l-2 border-brand-primary bg-brand-bg-light px-2.5 py-1 text-[13px] leading-snug text-ink-secondary">
-        <Info className="mt-px h-3.5 w-3.5 shrink-0 text-brand-primary" aria-hidden />
-        <span>
-          売上目標 <strong className="text-brand-primary">+6.0億円</strong>{" "}
-          を達成するために必要な人的資本投資ポイント
-          <strong className="text-brand-primary">（6,000P）</strong>
-          からの逆算で各指標の目標値を算出しています。
-          <span className="block">
-            各指標間の係数は文献値（柳モデル・人的資本可視化指針）に基づく仮置き。運用しながら実データを蓄積し、
-            <strong className="text-brand-primary">2030年を目処</strong>
-            に精緻化を進めます。
-          </span>
-          <span className="text-ink-secondary">
-            各カードの 🔍 アイコンで詳細を表示。
-          </span>
-        </span>
       </div>
 
       {/* 5列グリッド + 矢印オーバーレイ */}
@@ -388,7 +359,7 @@ function CascadeBoardInner() {
 
         {/* 列3: 会社への効果（KPI 4個） */}
         <Column title="会社への効果 (KPI)" tone="leading">
-          {COMPANY_EFFECT_IDS.filter((id) => visibleByTab(id)).map((id) => {
+          {COMPANY_EFFECT_IDS.map((id) => {
             const c = cardOf(id);
             const d = displayOf(id);
             return c ? (
@@ -421,7 +392,7 @@ function CascadeBoardInner() {
 
         {/* 列4: 事業実績・外部評価（中間9項目） */}
         <Column title="事業実績・外部評価" tone="bridge">
-          {MID_IDS.filter((id) => visibleByTab(id)).map((id) => {
+          {MID_IDS.map((id) => {
             const c = cardOf(id);
             const d = displayOf(id);
             return c ? (

--- a/frontend/src/components/cascade/IndicatorCard.tsx
+++ b/frontend/src/components/cascade/IndicatorCard.tsx
@@ -39,14 +39,15 @@ export function formatNum(
   if (unit === "%") return `${v.toFixed(1)}%`;
   if (unit === "スコア") return v.toFixed(2);
   if (unit === "名") return `${Math.round(v).toLocaleString()}名`;
-  if (unit === "件") return `${Math.round(v)}件`;
+  if (unit === "件") return `${v.toFixed(1)}件`;
   if (unit === "万kW") return `${v.toFixed(1)}万kW`;
   if (unit === "万t") return `${v.toFixed(1)}万t`;
   if (unit === "万件") return `${v.toFixed(1)}万件`;
-  if (unit === "千円/戸") return `${Math.round(v)}千円/戸`;
-  if (unit === "年連続") return `${Math.round(v)}年連続`;
-  if (unit === "年連続第1位") return `${Math.round(v)}年連続第1位`;
-  if (unit === "指数") return `${Math.round(v)}指数`;
+  if (unit === "千円/戸") return `${v.toFixed(1)}千円/戸`;
+  if (unit === "年連続") return `${v.toFixed(1)}年連続`;
+  if (unit === "年連続第1位") return `${v.toFixed(1)}年連続第1位`;
+  if (unit === "指数") return `${v.toFixed(1)}指数`;
+  if (unit === "日") return `${v.toFixed(2)}日`;
   if (unit === "億円") return `${v >= 0 ? "+" : ""}${v.toFixed(1)} 億円`;
   if (unit === "億kWh") return `${v.toFixed(1)} 億kWh`;
   return String(v);
@@ -64,11 +65,12 @@ export function deltaText(delta: number, unit?: string | null): string {
   if (unit === "万件") return `${sign}${abs.toFixed(1)}万件`;
   if (unit === "万t") return `${sign}${abs.toFixed(1)}万t`;
   if (unit === "万kW") return `${sign}${abs.toFixed(1)}万kW`;
-  if (unit === "件") return `${sign}${Math.round(abs)}件`;
+  if (unit === "件") return `${sign}${abs.toFixed(1)}件`;
   if (unit === "名") return `${sign}${Math.round(abs).toLocaleString()}名`;
-  if (unit === "年連続" || unit === "年連続第1位") return `${sign}${Math.round(abs)}年`;
-  if (unit === "千円/戸") return `${sign}${Math.round(abs)}千円/戸`;
-  if (unit === "指数") return `${sign}${Math.round(abs)}`;
+  if (unit === "年連続" || unit === "年連続第1位") return `${sign}${abs.toFixed(1)}年`;
+  if (unit === "千円/戸") return `${sign}${abs.toFixed(1)}千円/戸`;
+  if (unit === "指数") return `${sign}${abs.toFixed(1)}`;
+  if (unit === "日") return `${sign}${abs.toFixed(2)}日`;
   return `${sign}${abs.toFixed(1)}`;
 }
 

--- a/frontend/src/lib/cascade/meta.ts
+++ b/frontend/src/lib/cascade/meta.ts
@@ -46,7 +46,8 @@ export const COMPANY_EFFECT_IDS = [
   "transform",
 ] as const;
 
-// 列4: 事業実績・外部評価（9項目）— ENG主導 → 定着主導 → 挑戦/変革主導 → 横断
+// 列4: 事業実績・外部評価（10項目）— ENG主導 → 定着主導 → 挑戦/変革主導 → 横断
+// v6: poc を region に統合し、presenteeism / absenteeism を追加
 export const MID_IDS = [
   "safety_zero",
   "safety_brand",
@@ -55,7 +56,8 @@ export const MID_IDS = [
   "recruit",
   "esg",
   "region",
-  "poc",
+  "presenteeism",
+  "absenteeism",
   "co2",
 ] as const;
 
@@ -305,16 +307,17 @@ export const INDICATOR_META: Record<string, IndicatorMeta> = {
   region: {
     description: {
       measures:
-        "地域社会との共創プロジェクト（自治体・住民・地元企業との協働事業）の年間実施件数",
-      measurement: "地域貢献活動・包括連携協定・地域課題解決事業の実施件数を集計",
+        "地域社会との共創プロジェクト（自治体・住民・地元企業・スタートアップ等との協働事業・PoC を含む）の年間実施件数",
+      measurement:
+        "地域貢献活動・包括連携協定・地域課題解決事業・社外パートナーとの共創PoC の実施件数を集計（v6: 旧 PoC 指標を統合）",
       targetRationale:
         "ACT2027 では 2027年度に 15件を目標。中間マイルストーンとして 2026年度末で 10件を案分目標に設定。" +
         REFINE_NOTE +
         " /* TODO: 中期計画との整合確認 */",
     },
-    target: 10,
+    target: 15,
     unit: "件",
-    baselineCurrent: 5,
+    baselineCurrent: 10,
   },
   esg: {
     description: {
@@ -329,19 +332,31 @@ export const INDICATOR_META: Record<string, IndicatorMeta> = {
     qualitativeCurrent: "主要指数組入実績あり",
     qualitativeTarget: "主要ESG指数組入維持",
   },
-  poc: {
+  presenteeism: {
     description: {
       measures:
-        "社外パートナー（スタートアップ・大学・他社）との共創型実証実験の年間実施数",
+        "出社しているが心身の不調により本来の能力を発揮できていない状態の少なさ（発揮度=100%-損失率）",
       measurement:
-        "共創プロジェクト管理台帳に登録されたPoC実施件数 /* TODO: カウント対象の定義確認 */",
+        "WHO-HPQ や東大1項目版を用いた自己申告サーベイで「100%発揮度」を集計。経産省「健康経営度調査」準拠 /* TODO: 西部ガスの実測方法確認 */",
       targetRationale:
-        "現在 5件（推定）→ 2026年度末 10件を中間目標。新規事業創出の前段階としてのPoC量を確保し、革新的事業開発のリードタイムを短縮。" +
+        "現在 80% → 2027年度末 85% を中間目標。経産省の調査で日本企業平均は84.4%、SAP事例では発揮度1pt改善で営業利益+1%。" +
         REFINE_NOTE,
     },
-    target: 10,
-    unit: "件",
-    baselineCurrent: 5,
+    target: 85,
+    unit: "%",
+  },
+  absenteeism: {
+    description: {
+      measures:
+        "心身の不調による年間欠勤日数（一人当たり）。少ないほど健康度が高い",
+      measurement:
+        "従業員一人当たりの病欠・心身不調による休業日数の年間合計。ISO30414 の人的資本開示項目に準拠",
+      targetRationale:
+        "現在 1.70日/年 → 2027年度末 1.50日/年 を目標。日本平均は約2日/年、健康経営優良法人ホワイト500の上位企業水準。" +
+        REFINE_NOTE,
+    },
+    target: 1.5,
+    unit: "日",
   },
   co2: {
     description: {


### PR DESCRIPTION
## 背景

PR #27 (closed, merged) で cascade 画面の UX・API 接続を整備したが、その後の動作確認で `calculator.py` の計算ロジック（v5 から未更新）に問題が見つかったため、本 PR で修正する。

- ROIC/ROE が proxy 計算で過大（理論値の約400倍）
- ROE_CURRENT が NOPAT ベースで誤計算（正しくは Net Income / Equity）
- 中間層の表示が `int()` 切捨てでインプット変化に追従しない
- 共創PoC が地域共創力と重複

## 主な変更

### backend/app/services/calculator.py
- `NET_INCOME_M` 定数を追加（純利益 5,400百万円）
- `ROE_CURRENT` を Net Income ベースに修正（≒6.3%）
- `OP_MARGIN` 定数を追加
- `ROE_CALIBRATION` / `ROIC_CALIBRATION` を削除し、理論チェーンに置換
- `_calc_financial`: ROIC/ROE を「売上効果 → NOPAT → ΔROIC/ΔROE」で導出
- 共創PoC削除、プレゼンティーイズム/アブセンティーイズムを中間層に追加
- 地域共創力の係数を強化（PoC吸収）

### backend/app/routers/cascade.py
- `_format_value` の `int()` 切捨てを `:.1f` に変更（変化が見えるように）
- `日` ユニットの処理を追加
- ROIC/ROE description を「ACT2027 目標 +0.2pt / +1.7pt の一部」に更新

### frontend/src/components/cascade/IndicatorCard.tsx
- 表示精度の整合

### frontend/src/lib/cascade/meta.ts
- 中間層のメタ情報を v6 に対応

## 動作確認

- [x] ブラウザで `/cascade` にアクセス
- [x] 入力ポイントで KPI層・中間層・財務層の全数値が変化
- [x] ROIC delta ≈ +0.006pt（理論値）
- [x] ROE delta ≈ +0.020pt（理論値）
- [x] プレゼン/アブセンが入力で動く（アブセンは減少方向）

## 関連 Issue / PR

- #27 (closed, merged) - cascade UX + API（本PRはその後段の計算ロジック修正）

---

## 追加: UI 整理（5/10 追加コミット）

5/10 のチームMTGを踏まえ、以下の UI 整理を本 PR に同梱：

### 背景

- ヘッダーの旧 TABS フィルター（「すべて/挑戦の指標/安心・安全」）は廃止対象
- タブ下の「逆算ロジック…係数は仮置き…2030年を目処に精緻化」3行は役員プレゼンで弱気な印象を与えるため削除

### 変更内容

`frontend/src/components/cascade/CascadeBoard.tsx`

- `TABS` / `TabKey` → `SCOPE_OPTIONS` / `ScopeKey`（**全社 / 自部署**）に置換
- `tab` state → `scope` state
- `visibleByTab` 関数とフィルター呼び出しを削除（全指標を常時表示）
- `Info` import と「逆算ロジック説明」div を削除
- `USER_DEPT_LABEL = "営業本部・福岡リビング営業部"` を追加（デモ用ハードコード、API化は次PR）

### 動作確認（追加分）

- [x] `/cascade` ヘッダーが「全社 / 営業本部・福岡リビング営業部」に切替
- [x] タブ下の3行説明が消える
- [x] 全指標が常時表示される
- [x] スコープ切替でハイライトが移動

### 関連 Issue

- Refs #17 (DASH-05 ダッシュボードのフィルタ・ソート)
  - 本 PR の UI 整理は #17 の新方針に合わせた整理（ソート機能は #17 のスコープ外として保留）
- 関連: #31 (open, dashboard v3) でフィルター機能を新たに実装
- 後続: スコープに応じた実データ反映（DB集計API + 統合）