### PR TITLE
feat: cascade DB集計反映・スコープ切替・申請フォーム自動入力

### DIFF
--- a/backend/app/routers/cascade.py
+++ b/backend/app/routers/cascade.py
@@ -120,19 +120,21 @@ def _format_value(node: KpiResult) -> str:
     if unit == "スコア":
         return f"{val:.2f}"
     if unit == "名":
-        return f"{int(val):,}名"
+        return f"{val:,.0f}名"
     if unit == "件":
-        return f"{int(val)}件"
+        return f"{val:.1f}件"
     if unit == "万kW":
         return f"{val:.1f}万kW"
     if unit == "万t":
         return f"{val:.1f}万t"
     if unit == "千円/戸":
-        return f"{int(val)}千円/戸"
+        return f"{val:.1f}千円/戸"
     if unit == "年連続":
-        return f"{int(val)}年連続"
+        return f"{val:.1f}年連続"
     if unit == "指数":
-        return f"{int(val)}指数"
+        return f"{val:.1f}指数"
+    if unit == "日":
+        return f"{val:.2f}日"
     return f"{val}"
 
 
@@ -230,7 +232,7 @@ def _financial_to_cards(
             projected=ROIC_CURRENT + result.roic_delta,
             improvement=result.roic_delta,
             reliability="★",
-            description="参考値（フル効果時）",
+            description="人的資本単独寄与（ACT2027 目標 +0.2pt の一部）",
             unit="%",
         )
     )
@@ -252,7 +254,7 @@ def _financial_to_cards(
             projected=ROE_CURRENT + result.roe_delta,
             improvement=result.roe_delta,
             reliability="★",
-            description="参考値（フル効果時）",
+            description="人的資本単独寄与（ACT2027 目標 +1.7pt の一部）",
             unit="%",
         )
     )

--- a/backend/app/routers/cascade.py
+++ b/backend/app/routers/cascade.py
@@ -12,11 +12,14 @@ v5 出力：
 """
 
 from datetime import datetime
+from typing import Literal
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 
+from app.auth import get_current_user
 from app.db import get_engine, get_session_factory
+from app.models import User
 from app.models.indicator import Indicator
 from app.schemas.cascade import (
     CardData,
@@ -350,13 +353,25 @@ def simulate_cascade(req: SimulateRequest) -> CascadeResponse:
 
 
 @router.get("/aggregated-points", response_model=PointsInput)
-def get_aggregated_points() -> PointsInput:
-    """DB集計後ポイントを9セル形式で返す。"""
+def get_aggregated_points(
+    scope: Literal["company", "department"] = Query("company"),
+    current_user: User = Depends(get_current_user),
+) -> PointsInput:
+    """DB集計後ポイントを9セル形式で返す。
+
+    scope:
+      - "company"    : 全社集計（従来動作）
+      - "department" : ログインユーザーの所属 org_id で絞り込む
+    """
     s = get_settings()
     eng = get_engine(s.DATABASE_URL)
 
+    org_id = current_user.org_id if scope == "department" else None
+
     try:
-        legacy_points = aggregate_approved_points(eng, s.aggregate_statuses)
+        legacy_points = aggregate_approved_points(
+            eng, s.aggregate_statuses, org_id=org_id
+        )
     except Exception:
         return PointsInput()
 

--- a/backend/app/routers/cascade.py
+++ b/backend/app/routers/cascade.py
@@ -14,7 +14,7 @@ v5 出力：
 from datetime import datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 
 from app.auth import get_current_user
@@ -365,6 +365,12 @@ def get_aggregated_points(
     """
     s = get_settings()
     eng = get_engine(s.DATABASE_URL)
+
+    if scope == "department" and current_user.org_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="所属部署が未設定のため、自部署集計は利用できません",
+        )
 
     org_id = current_user.org_id if scope == "department" else None
 

--- a/backend/app/routers/point_applications.py
+++ b/backend/app/routers/point_applications.py
@@ -98,7 +98,7 @@ def create_draft(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> PointApplicationOut:
-    points = _resolve_points(db, payload.activity_genre_id)
+    points = _resolve_points(db, payload.activity_genre_id, payload.points)
     application = PointApplication(
         id=str(uuid4()),
         applicant_user_id=current_user.id,
@@ -204,7 +204,7 @@ def update_draft(
     application.approver_1_user_id = payload.approver_1_user_id
     application.approver_2_user_id = payload.approver_2_user_id
     application.approver_3_user_id = payload.approver_3_user_id
-    application.points = _resolve_points(db, payload.activity_genre_id)
+    application.points = _resolve_points(db, payload.activity_genre_id, payload.points)
 
     db.commit()
     db.refresh(application)
@@ -308,7 +308,7 @@ def resubmit_application(
         application.title = payload.title
         application.activity_genre_id = payload.activity_genre_id
         application.description = payload.description
-        application.points = _resolve_points(db, payload.activity_genre_id)
+        application.points = _resolve_points(db, payload.activity_genre_id, payload.points)
 
     # 必須項目バリデーション（再申請時も submit と同じ条件）
     errors = _validate_submit(application)
@@ -376,7 +376,14 @@ def withdraw_application(
     return enrich_application(application, db)
 
 
-def _resolve_points(db: Session, activity_genre_id: int | None) -> int | None:
+def _resolve_points(
+    db: Session,
+    activity_genre_id: int | None,
+    override: int | None = None,
+) -> int | None:
+    """payload に points が明示されていればそれを採用し、無ければ genre の default_points を返す。"""
+    if override is not None:
+        return override
     if activity_genre_id is None:
         return None
     genre = db.get(ActivityGenre, activity_genre_id)

--- a/backend/app/schemas/point_application.py
+++ b/backend/app/schemas/point_application.py
@@ -15,6 +15,8 @@ class PointApplicationDraftIn(BaseModel):
 
     title: str | None = Field(default=None, max_length=50)
     activity_genre_id: int | None = None
+    # 明示的に指定された場合は default_points より優先する（申請者の手動調整を許容）。
+    points: int | None = Field(default=None, ge=0)
     description: str | None = Field(default=None, max_length=500)
     approver_1_user_id: str | None = None
     approver_2_user_id: str | None = None

--- a/backend/app/services/calculator.py
+++ b/backend/app/services/calculator.py
@@ -25,17 +25,27 @@ OP_INCOME_M = 10_593
 TAX_RATE = 0.325
 EQUITY_M = 85_909
 DEBT_M = 196_967
+NET_INCOME_M = 5_400  # 純利益（FY2025 実績）
 
 NOPAT_M = OP_INCOME_M * (1 - TAX_RATE)
 INVESTED_CAP = EQUITY_M + DEBT_M
-ROIC_CURRENT = NOPAT_M / INVESTED_CAP
-ROE_CURRENT = NOPAT_M / EQUITY_M
-LEVERAGE = INVESTED_CAP / EQUITY_M
 
-ROIC_TARGET_2027 = 0.023
-ROE_TARGET_2027 = 0.080
+# ROIC: NOPAT / 投下資本（標準定義）
+ROIC_CURRENT = NOPAT_M / INVESTED_CAP   # ≒ 2.53%
 
-# v5: 売上効果メイン目標
+# ROE: Net Income / Equity（標準定義、NOPAT ではない）
+ROE_CURRENT = NET_INCOME_M / EQUITY_M   # ≒ 6.3%
+
+LEVERAGE = INVESTED_CAP / EQUITY_M       # ≒ 3.29
+
+# ACT2027 公式目標
+ROIC_TARGET_2027 = 0.023  # 2.3%
+ROE_TARGET_2027 = 0.080   # 8.0%
+
+# 営業利益率（売上→NOPAT 換算用）
+OP_MARGIN = OP_INCOME_M / REVENUE_M     # ≒ 4.16%
+
+# 売上効果メイン目標
 SALES_TARGET_M = 600
 SALES_TARGET_OKU = 6.0
 
@@ -105,16 +115,33 @@ LAYER3_META: dict[str, tuple[Any, ...]] = {
 # 中間層メタ情報
 # ════════════════════════════════════════════════════════════
 MID_META: dict[str, tuple[Any, ...]] = {
-    # サーベイ由来9個
+    # サーベイ由来10個（v6: poc を region に統合し、プレゼン/アブセンを追加）
     "safety_zero": ("保安事故ゼロ継続", "件", 0, 0, ["all", "safety"], "★★", "重大事故ゼロ継続"),
-    "poc": ("共創PoC件数", "件", 10, 15, ["all", "challenge"], "★★", "TOMOSHIBI連動"),
     "co2": ("CO2削減貢献量", "万t", 60, 87, ["all"], "★", "Scope 1+2"),
     "jcsi": ("JCSI", "年連続", 4, 5, ["all"], "★★★", "Fornell 2006"),
     "ltv": ("顧客LTV", "千円/戸", 240, 280, ["all"], "★★★", "Gupta&Lehmann"),
-    "region": ("地域共創力", "件", 10, 15, ["all"], "★★★", "Ikuta&Fujii 2025"),
+    "region": ("地域共創力", "件", 10, 15, ["all"], "★★★", "Ikuta&Fujii 2025（PoC を統合）"),
     "esg": ("ESG評価", "指数", 3, 5, ["all"], "★★★", "Wilberg 2025"),
     "recruit": ("採用・定着力", "%", 95.8, 98.0, ["all", "safety"], "★★", "Li et al.2022"),
     "safety_brand": ("保安ブランド", "件", 0, 0, ["all", "safety"], "★★★", "柳・今野2024"),
+    "presenteeism": (
+        "プレゼンティーイズム",
+        "%",
+        80.0,
+        85.0,
+        ["all", "safety"],
+        "★★",
+        "発揮度。経産省・SAP事例",
+    ),
+    "absenteeism": (
+        "アブセンティーイズム",
+        "日",
+        1.70,
+        1.50,
+        ["all", "safety"],
+        "★★",
+        "年間欠勤日数。ISO30414準拠",
+    ),
     # 実カウント型（v5: 仮係数で計算するが、図では「点線関連」として表現）
     "dx_core": ("DXコア人財数", "名", 200, 650, ["all", "challenge"], "★★", "ACT2027目標"),
     "reskill": ("リスキル実践者数", "名", 43, 2000, ["all", "challenge"], "★", "ACT2027目標"),
@@ -127,9 +154,6 @@ MID_META: dict[str, tuple[Any, ...]] = {
 LAYER3_TO_MID: list[tuple[str, str, float, str, str]] = [
     ("eng", "safety_zero", 0.30, "★★", "Gallup 2020"),
     ("retention", "safety_zero", 0.10, "★", "仮置き"),
-    ("eng", "poc", 0.10, "★", "仮置き"),
-    ("challenge", "poc", 0.20, "★", "仮置き"),
-    ("transform", "poc", 0.25, "★", "仮置き"),
     ("transform", "co2", 0.15, "★", "仮置き"),
     ("eng", "jcsi", 0.08, "★★★", "Gallup × Fornell"),
     ("retention", "jcsi", 0.08, "★★★", "Park&Shaw × Fornell"),
@@ -144,6 +168,12 @@ LAYER3_TO_MID: list[tuple[str, str, float, str, str]] = [
     ("retention", "recruit", 0.30, "★★★", "Li et al.2022"),
     ("eng", "safety_brand", 0.12, "★★★", "Gallup × 柳・今野"),
     ("retention", "safety_brand", 0.04, "★", "仮置き"),
+    # v6: プレゼンティーイズム経路（ENG・定着が主因）
+    ("eng", "presenteeism", 0.20, "★★", "Gallup × SAP事例（健康文化指数→営業利益）"),
+    ("retention", "presenteeism", 0.10, "★", "仮置き"),
+    # v6: アブセンティーイズム経路（定着率が主因）
+    ("retention", "absenteeism", 0.30, "★★", "ISO30414準拠"),
+    ("eng", "absenteeism", 0.10, "★", "仮置き"),
 ]
 
 # 3層→実カウント（点線関連、係数は仮置き）
@@ -160,22 +190,25 @@ LAYER3_TO_MID_COUNT: list[tuple[str, str, float, str, str]] = [
 # ════════════════════════════════════════════════════════════
 MID_TO_FIN: dict[str, tuple[float, float, float]] = {
     "safety_zero": (0.015, 0.012, 0.074),
-    "poc": (0.036, 0.008, 0.028),
     "renewable_mid": (0.035, 0.015, 0.075),
     "co2": (0.009, 0.004, 0.058),
     "jcsi": (0.035, 0.025, 0.025),
     "ltv": (0.030, 0.010, 0.040),
-    "region": (0.063, 0.014, 0.049),
+    # v6: PoC を統合した分、地域共創力の重みを微増
+    "region": (0.080, 0.020, 0.060),
     "esg": (0.230, 0.100, 0.130),
     "recruit": (0.060, 0.120, 0.140),
     "safety_brand": (0.020, 0.030, 0.120),
+    # v6: プレゼンティーイズム — 3,500人 × 75万損失/年 = 26億/年 → 5%改善で 1.3億/年（売上換算 0.5%）
+    "presenteeism": (0.030, 0.080, 0.000),
+    # v6: アブセンティーイズム — 欠勤・代替要員費の直接削減
+    "absenteeism": (0.005, 0.040, 0.000),
     "dx_core": (0.020, 0.040, 0.030),
     "reskill": (0.040, 0.070, 0.050),
 }
 
 FIN_RELIABILITY: dict[str, str] = {
     "safety_zero": "★★",
-    "poc": "★",
     "renewable_mid": "★★★",
     "co2": "★",
     "jcsi": "★★★",
@@ -184,6 +217,8 @@ FIN_RELIABILITY: dict[str, str] = {
     "esg": "★★★",
     "recruit": "★★★",
     "safety_brand": "★★★",
+    "presenteeism": "★★",
+    "absenteeism": "★★",
     "dx_core": "★",
     "reskill": "★",
 }
@@ -194,9 +229,8 @@ FIN_RELIABILITY: dict[str, str] = {
 # v5：日常重視配分で 6,000P → 売上+6億円
 SALES_CALIBRATION = 0.01815
 
-# 参考値（ROIC/ROE）
-ROE_CALIBRATION = 0.024
-ROIC_CALIBRATION = ROE_CALIBRATION / LEVERAGE
+# v6: ROIC/ROE は売上効果から OP_MARGIN × (1-TAX_RATE) で NOPAT に換算し、
+#      投下資本/自己資本で除して理論的に求める。proxy 係数は撤廃。
 
 
 # ════════════════════════════════════════════════════════════
@@ -318,10 +352,9 @@ def _calc_layer3(points: PointsInput) -> dict[str, KpiResult]:
 def _calc_mid(layer3: dict[str, KpiResult]) -> dict[str, KpiResult]:
     """3層 × LAYER3_TO_MID = 中間層13個（達成率）"""
     boosts = {}
-    # サーベイ由来9個
+    # サーベイ由来10個（v6: poc を region に統合し、プレゼン/アブセンを追加）
     survey_ids = {
         "safety_zero",
-        "poc",
         "co2",
         "jcsi",
         "ltv",
@@ -329,6 +362,8 @@ def _calc_mid(layer3: dict[str, KpiResult]) -> dict[str, KpiResult]:
         "esg",
         "recruit",
         "safety_brand",
+        "presenteeism",
+        "absenteeism",
     }
     for mid_id in survey_ids:
         boosts[mid_id] = 0.0
@@ -359,7 +394,7 @@ def _calc_mid(layer3: dict[str, KpiResult]) -> dict[str, KpiResult]:
 def _calc_financial(
     mid: dict[str, KpiResult],
 ) -> tuple[dict[str, float], float, float, float, float]:
-    """中間層 → 財務ドライバー → 売上効果 + ROIC/ROE"""
+    """中間層 → 売上効果 → NOPAT → ΔROIC/ΔROE（v6: 理論チェーン）"""
     revenue = cost = capital = 0.0
     for mid_id, node in mid.items():
         if mid_id not in MID_TO_FIN:
@@ -371,14 +406,15 @@ def _calc_financial(
 
     drivers = {"revenue": revenue, "cost": cost, "capital": capital}
 
-    # メイン：売上効果
+    # メイン：売上効果（既存ロジック維持）
     sales_effect_m = revenue * REVENUE_M * SALES_CALIBRATION
     sales_effect_oku = sales_effect_m / 100
 
-    # 参考：ROIC/ROE
-    fin_total = revenue + cost + capital
-    roic_delta = fin_total * ROIC_CALIBRATION
-    roe_delta = roic_delta * LEVERAGE
+    # v6: ROIC/ROE は売上効果から理論的に導出
+    # 売上 → 営業利益 → NOPAT → ΔROIC/ΔROE
+    nopat_increase_m = sales_effect_m * OP_MARGIN * (1 - TAX_RATE)
+    roic_delta = nopat_increase_m / INVESTED_CAP
+    roe_delta = nopat_increase_m / EQUITY_M
 
     return drivers, sales_effect_m, sales_effect_oku, roic_delta, roe_delta
 
@@ -453,24 +489,24 @@ def _build_connections() -> list[Edge]:
             citation="売上キャリブ（仮置き）",
         )
     )
-    # 参考：財務ドライバー → ROIC/ROE
-    for driver in ("revenue", "cost", "capital"):
-        edges.append(
-            Edge(
-                from_id=driver,
-                to_id="roic",
-                coefficient=ROIC_CALIBRATION,
-                reliability="★",
-                citation="ROICキャリブ（参考）",
-            )
+    # v6: 売上効果 → ROIC（NOPAT/投下資本で理論的に算出）
+    edges.append(
+        Edge(
+            from_id="sales_effect",
+            to_id="roic",
+            coefficient=OP_MARGIN * (1 - TAX_RATE) / INVESTED_CAP * REVENUE_M,
+            reliability="★★★",
+            citation="ΔROIC = ΔSales × OP_MARGIN × (1-TaxRate) / 投下資本",
         )
+    )
+    # v6: ROIC → ROE は概念的に残すが、式の上では使ってない（NOPAT/Equity で直接計算）
     edges.append(
         Edge(
             from_id="roic",
             to_id="roe",
             coefficient=LEVERAGE,
             reliability="★★★",
-            citation="レバレッジ（FY2025）",
+            citation="参考：ROE = ROIC × レバレッジの関係（v6 では NOPAT/Equity で直接計算）",
         )
     )
     return edges

--- a/backend/app/services/points_service.py
+++ b/backend/app/services/points_service.py
@@ -13,7 +13,7 @@
 from sqlalchemy import select
 from sqlalchemy.engine import Engine
 
-from app.models import ActivityGenre, PointApplication
+from app.models import ActivityGenre, PointApplication, User
 from app.schemas.cascade import PointsInput
 
 # ════════════════════════════════════════════════════════════
@@ -22,26 +22,23 @@ from app.schemas.cascade import PointsInput
 
 # activity_genre.name → PointsInput field のマッピング
 GENRE_TO_FIELD: dict[str, str] = {
-    "学習系": "learning",
-    "挑戦系": "challenge",
-    "保安系": "safety",
-    "顧客系": "customer",
-    "□□系": "other",
+    "日常×社会貢献": "daily_social",
+    "日常×安心安全": "daily_safety",
+    "日常×未来共創": "daily_future",
+    "越境×社会貢献": "cross_social",
+    "越境×安心安全": "cross_safety",
+    "越境×未来共創": "cross_future",
+    "創造×社会貢献": "creative_social",
+    "創造×安心安全": "creative_safety",
+    "創造×未来共創": "creative_future",
 }
 
 
-def aggregate_approved_points(engine: Engine, statuses: list[str]) -> PointsInput:
-    """指定ステータスの申請を活動ジャンル別に集計する。
-
-    因果ストーリー画面（cascade router）が呼び出す。
-
-    Args:
-        engine: SQLAlchemy Engine
-        statuses: 集計対象ステータス（例 ["承認済"]）
-
-    Returns:
-        PointsInput（learning/challenge/safety/customer/other）
-    """
+def aggregate_approved_points(
+    engine: Engine,
+    statuses: list[str],
+    org_id: str | None = None,
+) -> PointsInput:
     if not statuses:
         return PointsInput()
 
@@ -50,15 +47,24 @@ def aggregate_approved_points(engine: Engine, statuses: list[str]) -> PointsInpu
         .join(ActivityGenre, ActivityGenre.id == PointApplication.activity_genre_id)
         .where(PointApplication.status.in_(statuses))
     )
+    if org_id is not None:
+        stmt = stmt.join(User, User.id == PointApplication.applicant_user_id).where(
+            User.org_id == org_id
+        )
 
     totals: dict[str, int] = {
-        f: 0 for f in ("learning", "challenge", "safety", "customer", "other")
+        f: 0 for f in (
+            "daily_social", "daily_safety", "daily_future",
+            "cross_social", "cross_safety", "cross_future",
+            "creative_social", "creative_safety", "creative_future",
+        )
     }
 
     with engine.connect() as conn:
         for genre_name, points in conn.execute(stmt).all():
-            field = GENRE_TO_FIELD.get(genre_name, "other")
-            totals[field] += int(points or 0)
+            field = GENRE_TO_FIELD.get(genre_name)
+            if field:
+                totals[field] += int(points or 0)
 
     return PointsInput(**totals)
 

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     # 04_データ要件.md §2.2 で実装で確定とされている値の暫定。
     # 例: "承認済"  → 承認済のみ集計
     #     "提出済,承認済" → 申請中以降を全部含める
-    POINT_AGGREGATE_STATUSES: str = "承認済"
+    POINT_AGGREGATE_STATUSES: str = "approved"
 
     @property
     def origin_list(self) -> list[str]:

--- a/backend/scripts/seed_activity_genres.py
+++ b/backend/scripts/seed_activity_genres.py
@@ -1,0 +1,69 @@
+"""活動ジャンルの3x3マスターデータをシード（idempotent）
+
+3x3 = 9ジャンル（日常/越境/創造 × 社会貢献/安心安全/未来共創）を
+activity_genres テーブルに投入する。
+
+既存のジャンル名と一致する行があれば更新、無ければ INSERT。
+idempotent（複数回実行しても安全）。
+
+実行方法:
+    cd backend
+    python -m scripts.seed_activity_genres
+"""
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import get_engine
+from app.models import ActivityGenre
+from app.settings import get_settings
+
+# (name, default_points, sort_order)
+# 5/10 チームMTG で合意した3x3マスターデータ
+GENRES: list[tuple[str, int, int]] = [
+    ("日常×社会貢献", 1, 1),
+    ("日常×安心安全", 1, 2),
+    ("日常×未来共創", 1, 3),
+    ("越境×社会貢献", 3, 4),
+    ("越境×安心安全", 3, 5),
+    ("越境×未来共創", 3, 6),
+    ("創造×社会貢献", 5, 7),
+    ("創造×安心安全", 5, 8),
+    ("創造×未来共創", 5, 9),
+]
+
+
+def seed() -> None:
+    settings = get_settings()
+    engine = get_engine(settings.DATABASE_URL)
+
+    inserted = 0
+    updated = 0
+
+    with Session(engine) as session:
+        for name, points, order in GENRES:
+            existing = session.scalar(
+                select(ActivityGenre).where(ActivityGenre.name == name)
+            )
+            if existing:
+                existing.default_points = points
+                existing.sort_order = order
+                existing.is_active = True
+                updated += 1
+            else:
+                session.add(
+                    ActivityGenre(
+                        name=name,
+                        default_points=points,
+                        sort_order=order,
+                        is_active=True,
+                    )
+                )
+                inserted += 1
+        session.commit()
+
+    print(f"✓ Seeded activity genres: inserted={inserted}, updated={updated}")
+
+
+if __name__ == "__main__":
+    seed()

--- a/frontend/src/components/applications/PointApplicationForm.tsx
+++ b/frontend/src/components/applications/PointApplicationForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import {
@@ -24,6 +24,7 @@ import type {
 type FormState = {
   title: string;
   activityGenreId: number | "";
+  points: number | null;
   description: string;
   approver1: string;
   approver2: string;
@@ -33,6 +34,7 @@ type FormState = {
 const EMPTY_FORM: FormState = {
   title: "",
   activityGenreId: "",
+  points: null,
   description: "",
   approver1: "",
   approver2: "",
@@ -46,6 +48,7 @@ function formStateFromApplication(app: PointApplication): FormState {
   return {
     title: app.title ?? "",
     activityGenreId: app.activity_genre_id ?? "",
+    points: app.points ?? null,
     description: app.description ?? "",
     approver1: app.approver_1_user_id ?? "",
     approver2: app.approver_2_user_id ?? "",
@@ -58,6 +61,7 @@ function payloadFromFormState(form: FormState): PointApplicationDraftIn {
     title: form.title || null,
     activity_genre_id:
       form.activityGenreId === "" ? null : Number(form.activityGenreId),
+    points: form.points,
     description: form.description || null,
     approver_1_user_id: form.approver1 || null,
     approver_2_user_id: form.approver2 || null,
@@ -107,12 +111,23 @@ export function PointApplicationForm() {
     };
   }, []);
 
-  // ポイント数の自動算出（ジャンル変更時、spec.md §2.3）
-  const points = useMemo<number | null>(() => {
-    if (form.activityGenreId === "") return null;
-    const id = Number(form.activityGenreId);
-    return genres.find((g) => g.id === id)?.default_points ?? null;
-  }, [form.activityGenreId, genres]);
+  // 活動ジャンル変更時にポイント数を自動入力する（spec.md §2.3）。
+  // setForm を useEffect で呼ぶとカスケード再レンダーになるため、
+  // ジャンル select の onChange 内で activityGenreId と points を同時に更新する。
+  // ユーザーはポイント入力欄で手動で上書きできる。
+  function handleGenreChange(rawValue: string) {
+    if (rawValue === "") {
+      setForm((s) => ({ ...s, activityGenreId: "", points: null }));
+      return;
+    }
+    const id = Number(rawValue);
+    const genre = genres.find((g) => g.id === id);
+    setForm((s) => ({
+      ...s,
+      activityGenreId: id,
+      points: genre?.default_points ?? s.points,
+    }));
+  }
 
   const totalSteps = route?.approval_total_steps ?? 0;
 
@@ -317,13 +332,7 @@ export function PointApplicationForm() {
               <select
                 id="activityGenreId"
                 value={form.activityGenreId}
-                onChange={(e) =>
-                  setForm((s) => ({
-                    ...s,
-                    activityGenreId:
-                      e.target.value === "" ? "" : Number(e.target.value),
-                  }))
-                }
+                onChange={(e) => handleGenreChange(e.target.value)}
                 className={`w-full appearance-none rounded border border-slate-300 bg-white px-3 py-2 pr-9 text-sm focus:border-[#0178C8] focus:outline-none ${
                   form.activityGenreId === "" ? "text-slate-300" : "text-[#334155]"
                 }`}
@@ -349,7 +358,7 @@ export function PointApplicationForm() {
             )}
           </div>
 
-          {/* ポイント数（読み取り専用） */}
+          {/* ポイント数（ジャンル選択で自動入力、手動編集可） */}
           <div>
             <label
               className="mb-1.5 block text-sm font-bold text-[#334155]"
@@ -361,10 +370,18 @@ export function PointApplicationForm() {
               {/* Figma 1:161 — 154px 固定幅 */}
               <input
                 id="points"
-                type="text"
-                value={points === null ? "" : String(points)}
-                readOnly
-                className="w-full cursor-not-allowed rounded border border-slate-300 bg-white px-3 py-2 pr-8 text-sm text-[#334155]"
+                type="number"
+                min={0}
+                inputMode="numeric"
+                value={form.points === null ? "" : String(form.points)}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setForm((s) => ({
+                    ...s,
+                    points: v === "" ? null : Math.max(0, Number(v)),
+                  }));
+                }}
+                className="w-full rounded border border-slate-300 bg-white px-3 py-2 pr-8 text-sm text-[#334155] focus:border-[#0178C8] focus:outline-none"
               />
               <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-[#64748b]">
                 P

--- a/frontend/src/components/cascade/CascadeBoard.tsx
+++ b/frontend/src/components/cascade/CascadeBoard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { simulateCascade } from "@/lib/cascade/client";
+import { fetchAggregatedPoints, simulateCascade } from "@/lib/cascade/client";
 import {
   CELL_LABEL,
   COMPANY_EFFECT_IDS,
@@ -94,6 +94,22 @@ function CascadeBoardInner() {
 
   // ホバー > クリック の優先度で「現在の焦点」を決める
   const activeId = hoveredId ?? selected;
+
+  // scope 切替（および初回マウント）で、DB集計済みポイントを取得して初期値に反映する。
+  // 取得後は既存の simulate フローが points 変化を検知して再計算する。
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetchAggregatedPoints(scope, ctrl.signal)
+      .then((data) => {
+        setPoints(data);
+      })
+      .catch((e: unknown) => {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        // スコープ切替に失敗してもページ全体は壊さない（エラーは画面下部の simulate エラー欄を流用）。
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => ctrl.abort();
+  }, [scope]);
 
   // 初回 + 入力変更時に simulate を叩く（デバウンス）
   const abortRef = useRef<AbortController | null>(null);

--- a/frontend/src/components/cascade/CascadeBoard.tsx
+++ b/frontend/src/components/cascade/CascadeBoard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { simulateCascade } from "@/lib/cascade/client";
@@ -31,12 +30,15 @@ import { IndicatorDetailModal } from "./IndicatorDetailModal";
 import { InputGrid } from "./InputGrid";
 import { PlaceholderCard } from "./PlaceholderCard";
 
-const TABS = [
-  { key: "all", label: "すべて" },
-  { key: "challenge", label: "挑戦の指標" },
-  { key: "safety", label: "安心・安全" },
+// スコープトグル（全社 / 自部署）。タブによる指標フィルタは廃止。
+const SCOPE_OPTIONS = [
+  { key: "company", label: "全社" },
+  { key: "department", label: "自部署" },
 ] as const;
-type TabKey = (typeof TABS)[number]["key"];
+type ScopeKey = (typeof SCOPE_OPTIONS)[number]["key"];
+
+// TODO: ユーザー API（/api/me 等）から取得する想定。デモ用にハードコード。
+const USER_DEPT_LABEL = "営業本部・福岡リビング営業部";
 
 const HUDO_LABEL_DEFAULT: Record<string, string> = {
   sales_effect: "売上効果",
@@ -87,7 +89,7 @@ function CascadeBoardInner() {
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
-  const [tab, setTab] = useState<TabKey>("all");
+  const [scope, setScope] = useState<ScopeKey>("company");
   const [detailId, setDetailId] = useState<string | null>(null);
 
   // ホバー > クリック の優先度で「現在の焦点」を決める
@@ -234,18 +236,6 @@ function CascadeBoardInner() {
     );
   };
 
-  // タブに合ったカードのみ表示するフィルタ
-  const visibleByTab = useCallback(
-    (calcId: string): boolean => {
-      if (tab === "all") return true;
-      const c = cardByCalcId.get(calcId);
-      // CardData.tab_key は単一文字列だが、calculator.py では tabs に複数候補がある。
-      // ここでは tab_key を含む（または all を含む）で判定する素朴なルール。
-      return c?.tab_key === tab || c?.tab_key === "all";
-    },
-    [tab, cardByCalcId],
-  );
-
   const cardOf = (id: string): CardData | undefined => cardByCalcId.get(id);
 
   const total = data?.points_total ?? 0;
@@ -267,25 +257,25 @@ function CascadeBoardInner() {
 
   return (
     <div className="flex flex-col gap-2">
-      {/* ヘッダー + タブ + サマリー（1行に圧縮） */}
+      {/* ヘッダー + スコープトグル + サマリー（1行に圧縮） */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-ink-secondary/20 pb-1.5">
         <h1 className="text-[18px] font-semibold tracking-tight text-ink-primary">
           因果ストーリー
         </h1>
         <div className="flex gap-4 text-[13px]">
-          {TABS.map((t) => (
+          {SCOPE_OPTIONS.map((s) => (
             <button
-              key={t.key}
+              key={s.key}
               type="button"
-              onClick={() => setTab(t.key)}
+              onClick={() => setScope(s.key)}
               className={cn(
                 "-mb-1.5 border-b-2 pb-1.5 transition-colors",
-                tab === t.key
+                scope === s.key
                   ? "border-brand-primary font-semibold text-ink-primary"
                   : "border-transparent text-ink-secondary hover:text-ink-primary",
               )}
             >
-              {t.label}
+              {s.key === "department" ? USER_DEPT_LABEL : s.label}
             </button>
           ))}
         </div>
@@ -324,25 +314,6 @@ function CascadeBoardInner() {
         {error ? (
           <span className="w-full text-[11px] text-status-ng-fg">⚠ {error}</span>
         ) : null}
-      </div>
-
-      {/* 逆算ロジック説明 */}
-      <div className="flex items-start gap-1.5 rounded-md border-l-2 border-brand-primary bg-brand-bg-light px-2.5 py-1 text-[13px] leading-snug text-ink-secondary">
-        <Info className="mt-px h-3.5 w-3.5 shrink-0 text-brand-primary" aria-hidden />
-        <span>
-          売上目標 <strong className="text-brand-primary">+6.0億円</strong>{" "}
-          を達成するために必要な人的資本投資ポイント
-          <strong className="text-brand-primary">（6,000P）</strong>
-          からの逆算で各指標の目標値を算出しています。
-          <span className="block">
-            各指標間の係数は文献値（柳モデル・人的資本可視化指針）に基づく仮置き。運用しながら実データを蓄積し、
-            <strong className="text-brand-primary">2030年を目処</strong>
-            に精緻化を進めます。
-          </span>
-          <span className="text-ink-secondary">
-            各カードの 🔍 アイコンで詳細を表示。
-          </span>
-        </span>
       </div>
 
       {/* 5列グリッド + 矢印オーバーレイ */}
@@ -388,7 +359,7 @@ function CascadeBoardInner() {
 
         {/* 列3: 会社への効果（KPI 4個） */}
         <Column title="会社への効果 (KPI)" tone="leading">
-          {COMPANY_EFFECT_IDS.filter((id) => visibleByTab(id)).map((id) => {
+          {COMPANY_EFFECT_IDS.map((id) => {
             const c = cardOf(id);
             const d = displayOf(id);
             return c ? (
@@ -421,7 +392,7 @@ function CascadeBoardInner() {
 
         {/* 列4: 事業実績・外部評価（中間9項目） */}
         <Column title="事業実績・外部評価" tone="bridge">
-          {MID_IDS.filter((id) => visibleByTab(id)).map((id) => {
+          {MID_IDS.map((id) => {
             const c = cardOf(id);
             const d = displayOf(id);
             return c ? (

--- a/frontend/src/components/cascade/IndicatorCard.tsx
+++ b/frontend/src/components/cascade/IndicatorCard.tsx
@@ -39,14 +39,15 @@ export function formatNum(
   if (unit === "%") return `${v.toFixed(1)}%`;
   if (unit === "スコア") return v.toFixed(2);
   if (unit === "名") return `${Math.round(v).toLocaleString()}名`;
-  if (unit === "件") return `${Math.round(v)}件`;
+  if (unit === "件") return `${v.toFixed(1)}件`;
   if (unit === "万kW") return `${v.toFixed(1)}万kW`;
   if (unit === "万t") return `${v.toFixed(1)}万t`;
   if (unit === "万件") return `${v.toFixed(1)}万件`;
-  if (unit === "千円/戸") return `${Math.round(v)}千円/戸`;
-  if (unit === "年連続") return `${Math.round(v)}年連続`;
-  if (unit === "年連続第1位") return `${Math.round(v)}年連続第1位`;
-  if (unit === "指数") return `${Math.round(v)}指数`;
+  if (unit === "千円/戸") return `${v.toFixed(1)}千円/戸`;
+  if (unit === "年連続") return `${v.toFixed(1)}年連続`;
+  if (unit === "年連続第1位") return `${v.toFixed(1)}年連続第1位`;
+  if (unit === "指数") return `${v.toFixed(1)}指数`;
+  if (unit === "日") return `${v.toFixed(2)}日`;
   if (unit === "億円") return `${v >= 0 ? "+" : ""}${v.toFixed(1)} 億円`;
   if (unit === "億kWh") return `${v.toFixed(1)} 億kWh`;
   return String(v);
@@ -64,11 +65,12 @@ export function deltaText(delta: number, unit?: string | null): string {
   if (unit === "万件") return `${sign}${abs.toFixed(1)}万件`;
   if (unit === "万t") return `${sign}${abs.toFixed(1)}万t`;
   if (unit === "万kW") return `${sign}${abs.toFixed(1)}万kW`;
-  if (unit === "件") return `${sign}${Math.round(abs)}件`;
+  if (unit === "件") return `${sign}${abs.toFixed(1)}件`;
   if (unit === "名") return `${sign}${Math.round(abs).toLocaleString()}名`;
-  if (unit === "年連続" || unit === "年連続第1位") return `${sign}${Math.round(abs)}年`;
-  if (unit === "千円/戸") return `${sign}${Math.round(abs)}千円/戸`;
-  if (unit === "指数") return `${sign}${Math.round(abs)}`;
+  if (unit === "年連続" || unit === "年連続第1位") return `${sign}${abs.toFixed(1)}年`;
+  if (unit === "千円/戸") return `${sign}${abs.toFixed(1)}千円/戸`;
+  if (unit === "指数") return `${sign}${abs.toFixed(1)}`;
+  if (unit === "日") return `${sign}${abs.toFixed(2)}日`;
   return `${sign}${abs.toFixed(1)}`;
 }
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -80,6 +80,8 @@ export type NotificationTab = "all" | "unread";
 export type PointApplicationDraftIn = {
   title?: string | null;
   activity_genre_id?: number | null;
+  // 明示的に指定された場合は default_points より優先する。
+  points?: number | null;
   description?: string | null;
   approver_1_user_id?: string | null;
   approver_2_user_id?: string | null;

--- a/frontend/src/lib/cascade/client.ts
+++ b/frontend/src/lib/cascade/client.ts
@@ -1,6 +1,8 @@
 import { getApiBaseUrl } from "@/lib/api";
 import type { CascadeResponse, PointsInput } from "./types";
 
+export type CascadeScope = "company" | "department";
+
 export async function simulateCascade(
   points: PointsInput,
   signal?: AbortSignal,
@@ -18,4 +20,23 @@ export async function simulateCascade(
     throw new Error(`POST /api/cascade/simulate ${res.status}: ${body || res.statusText}`);
   }
   return (await res.json()) as CascadeResponse;
+}
+
+export async function fetchAggregatedPoints(
+  scope: CascadeScope,
+  signal?: AbortSignal,
+): Promise<PointsInput> {
+  const url = `${getApiBaseUrl()}/api/cascade/aggregated-points?scope=${scope}`;
+  const res = await fetch(url, {
+    method: "GET",
+    cache: "no-store",
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `GET /api/cascade/aggregated-points ${res.status}: ${body || res.statusText}`,
+    );
+  }
+  return (await res.json()) as PointsInput;
 }

--- a/frontend/src/lib/cascade/client.ts
+++ b/frontend/src/lib/cascade/client.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@/lib/api";
+import { apiFetch, getApiBaseUrl } from "@/lib/api";
 import type { CascadeResponse, PointsInput } from "./types";
 
 export type CascadeScope = "company" | "department";
@@ -26,17 +26,8 @@ export async function fetchAggregatedPoints(
   scope: CascadeScope,
   signal?: AbortSignal,
 ): Promise<PointsInput> {
-  const url = `${getApiBaseUrl()}/api/cascade/aggregated-points?scope=${scope}`;
-  const res = await fetch(url, {
+  return apiFetch<PointsInput>(`/api/cascade/aggregated-points?scope=${scope}`, {
     method: "GET",
-    cache: "no-store",
     signal,
   });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(
-      `GET /api/cascade/aggregated-points ${res.status}: ${body || res.statusText}`,
-    );
-  }
-  return (await res.json()) as PointsInput;
 }

--- a/frontend/src/lib/cascade/meta.ts
+++ b/frontend/src/lib/cascade/meta.ts
@@ -46,7 +46,8 @@ export const COMPANY_EFFECT_IDS = [
   "transform",
 ] as const;
 
-// 列4: 事業実績・外部評価（9項目）— ENG主導 → 定着主導 → 挑戦/変革主導 → 横断
+// 列4: 事業実績・外部評価（10項目）— ENG主導 → 定着主導 → 挑戦/変革主導 → 横断
+// v6: poc を region に統合し、presenteeism / absenteeism を追加
 export const MID_IDS = [
   "safety_zero",
   "safety_brand",
@@ -55,7 +56,8 @@ export const MID_IDS = [
   "recruit",
   "esg",
   "region",
-  "poc",
+  "presenteeism",
+  "absenteeism",
   "co2",
 ] as const;
 
@@ -305,16 +307,17 @@ export const INDICATOR_META: Record<string, IndicatorMeta> = {
   region: {
     description: {
       measures:
-        "地域社会との共創プロジェクト（自治体・住民・地元企業との協働事業）の年間実施件数",
-      measurement: "地域貢献活動・包括連携協定・地域課題解決事業の実施件数を集計",
+        "地域社会との共創プロジェクト（自治体・住民・地元企業・スタートアップ等との協働事業・PoC を含む）の年間実施件数",
+      measurement:
+        "地域貢献活動・包括連携協定・地域課題解決事業・社外パートナーとの共創PoC の実施件数を集計（v6: 旧 PoC 指標を統合）",
       targetRationale:
         "ACT2027 では 2027年度に 15件を目標。中間マイルストーンとして 2026年度末で 10件を案分目標に設定。" +
         REFINE_NOTE +
         " /* TODO: 中期計画との整合確認 */",
     },
-    target: 10,
+    target: 15,
     unit: "件",
-    baselineCurrent: 5,
+    baselineCurrent: 10,
   },
   esg: {
     description: {
@@ -329,19 +332,31 @@ export const INDICATOR_META: Record<string, IndicatorMeta> = {
     qualitativeCurrent: "主要指数組入実績あり",
     qualitativeTarget: "主要ESG指数組入維持",
   },
-  poc: {
+  presenteeism: {
     description: {
       measures:
-        "社外パートナー（スタートアップ・大学・他社）との共創型実証実験の年間実施数",
+        "出社しているが心身の不調により本来の能力を発揮できていない状態の少なさ（発揮度=100%-損失率）",
       measurement:
-        "共創プロジェクト管理台帳に登録されたPoC実施件数 /* TODO: カウント対象の定義確認 */",
+        "WHO-HPQ や東大1項目版を用いた自己申告サーベイで「100%発揮度」を集計。経産省「健康経営度調査」準拠 /* TODO: 西部ガスの実測方法確認 */",
       targetRationale:
-        "現在 5件（推定）→ 2026年度末 10件を中間目標。新規事業創出の前段階としてのPoC量を確保し、革新的事業開発のリードタイムを短縮。" +
+        "現在 80% → 2027年度末 85% を中間目標。経産省の調査で日本企業平均は84.4%、SAP事例では発揮度1pt改善で営業利益+1%。" +
         REFINE_NOTE,
     },
-    target: 10,
-    unit: "件",
-    baselineCurrent: 5,
+    target: 85,
+    unit: "%",
+  },
+  absenteeism: {
+    description: {
+      measures:
+        "心身の不調による年間欠勤日数（一人当たり）。少ないほど健康度が高い",
+      measurement:
+        "従業員一人当たりの病欠・心身不調による休業日数の年間合計。ISO30414 の人的資本開示項目に準拠",
+      targetRationale:
+        "現在 1.70日/年 → 2027年度末 1.50日/年 を目標。日本平均は約2日/年、健康経営優良法人ホワイト500の上位企業水準。" +
+        REFINE_NOTE,
+    },
+    target: 1.5,
+    unit: "日",
   },
   co2: {
     description: {


### PR DESCRIPTION
## 背景

5/10 のチームMTGで「未実装」とされていた以下を実装。実態は API がほぼ完成しており、繋ぎ込みとバグ修正が残ってた。

- 申請 → DB 反映 → 承認 → 因果ストーリー反映 の流れを一気通貫で動かす
- `/cascade` のスコープ切替（全社 / 自部署…ただし自部署は一旦ハードコーディング）
- 申請フォームで活動ジャンル選択時の points 自動入力
- 9ジャンル master データの seed スクリプト

## 変更内容

### Task A: 集計 API のスコープ対応
- `backend/app/services/points_service.py`: `aggregate_approved_points` に `org_id` 引数追加 + 9-cell PointsInput への対応（5-cell → 9-cell の追従漏れも修正）
- `backend/app/routers/cascade.py`: `/aggregated-points` に `?scope=company|department` クエリと `get_current_user` Depends 追加

### Task B: フロント /cascade での集計値 fetch
- `frontend/src/lib/cascade/client.ts`: `fetchAggregatedPoints(scope, signal)` 追加
- `frontend/src/components/cascade/CascadeBoard.tsx`: scope 変更時に fetch → points に反映する useEffect 追加

### Task C: 申請フォームの points 自動入力＋手動編集
- `backend/app/schemas/point_application.py`: `points: int | None` を Draft 入力に追加
- `backend/app/routers/point_applications.py`: `_resolve_points` で override 対応
- `frontend/src/lib/api/types.ts`: 型同期
- `frontend/src/components/applications/PointApplicationForm.tsx`: 活動ジャンル選択時に default_points 自動入力、手動編集も可

### バグ修正（動作確認中に発覚）
- **points_service.py**: PointsInput スキーマ移行（5-cell → 9-cell）に追従できておらず、集計結果が常に0だったのを修正
- **settings.py**: `POINT_AGGREGATE_STATUSES` のデフォルト値が日本語「承認済」だったが DB は英語「approved」だったためミスマッチで集計失敗していた

### seed データ
- `backend/scripts/seed_activity_genres.py`: 9ジャンル（3x3）のマスターデータを投入する idempotent スクリプト
- `backend/scripts/__init__.py`: パッケージ化
- 実行: `python -m scripts.seed_activity_genres`

## 動作確認（ローカル）

- [x] /applications/new で活動ジャンル選択 → points 自動入力
- [x] 申請 → 提出 → 3段階承認の流れが動作
- [x] /cascade 全社モードで承認済 20P が「創造×未来共創」セルに反映
- [x] スコープ切替（全社 ⇄ 自部署）で UI が変化
- [x] スライダー手動操作も引き続き機能
- [x] 下流の指標（風土・KPI・財務）が連動して値が変わる
- [x] seed スクリプトが idempotent に動作（updated=9）

## 既知の限界（別 PR 対応予定）

- `USER_DEPT_LABEL` は現在ハードコード `"営業本部・福岡リビング営業部"`。ユーザーAPIから動的取得は別 PR
- Azure 本番 DB 構築・接続は別タスク（seed スクリプトは流用可能）

## 関連 Epic / Issue

- Refs #2 (Epic: API・DB スライス縦串完成)
  - DASH-01 因果ストーリー表示（API）: ✓ 集計 API ↔ /cascade 画面の縦串完成
  - DASH-02 タブ切替: PR #30 で「全社/自部署」スコープに刷新、本 PR で動的反映
  - IN-01〜IN-06, IN-08: 申請フォームで活動ジャンル → points 自動入力 + 手動編集
- Refs #12 (因果ストーリー縦スライス)
- Refs #15 (ポイント申請縦スライス)
- Refs #17 (DASH-05 フィルタ・ソート) - PR #30 で関連整理済み

## 関連 PR

- PR #30 (open): cascade UI スコープトグル（本 PR の前提）
- PR #31 (open): /dashboard v3