### PR TITLE
fix(backend): MySQL 互換の submitted_at 並び（NULLS LAST 撤去）

### DIFF
--- a/backend/app/query_order.py
+++ b/backend/app/query_order.py
@@ -1,0 +1,26 @@
+"""方言差分を吸収する ORDER BY 用ヘルパー。
+
+Azure MySQL 等は `ORDER BY col DESC NULLS LAST`（SQLAlchemy の `.nulls_last()` が
+生成する句）を解釈できず 1064 になる。PostgreSQL と同等の並びを CASE で表現する。
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import ColumnElement, case
+
+
+def submitted_at_desc_nulls_last(
+    submitted_at: ColumnElement,
+    *tiebreakers: object,
+) -> tuple[object, ...]:
+    """submitted_at 降順で、NULL の行を末尾へ（PostgreSQL の NULLS LAST 相当）。
+
+    Args:
+        submitted_at: ソート対象カラム
+        tiebreakers: submitted_at が同順位のときの追加キー（例: `.desc()` 付きカラム）
+    """
+    return (
+        case((submitted_at.is_(None), 1), else_=0),
+        submitted_at.desc(),
+        *tiebreakers,
+    )

--- a/backend/app/routers/approvals.py
+++ b/backend/app/routers/approvals.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session, aliased
 from app.auth import get_current_user
 from app.db import get_db
 from app.models import ActivityGenre, PointApplication, User
+from app.query_order import submitted_at_desc_nulls_last
 from app.schemas.master import UserBriefOut
 from app.schemas.point_application import PointApplicationOut
 from app.services.applications import (
@@ -171,10 +172,12 @@ def list_approvals(
             )
         )
 
-    # spec.md §3.7 — 新しい順
+    # spec.md §3.7 — 新しい順（MySQL 互換: NULLS LAST は使わない）
     stmt = stmt.order_by(
-        PointApplication.submitted_at.desc().nulls_last(),
-        PointApplication.created_at.desc(),
+        *submitted_at_desc_nulls_last(
+            PointApplication.submitted_at,
+            PointApplication.created_at.desc(),
+        )
     )
 
     if post_filter is None:

--- a/backend/app/routers/point_applications.py
+++ b/backend/app/routers/point_applications.py
@@ -18,6 +18,7 @@ from app.models import (
     PointApplication,
     User,
 )
+from app.query_order import submitted_at_desc_nulls_last
 from app.routers.users import APPROVAL_ROUTE_BY_ROLE
 from app.schemas.point_application import (
     PointApplicationDraftIn,
@@ -158,8 +159,10 @@ def list_my_applications(
         stmt = stmt.order_by(PointApplication.updated_at.desc())
     else:
         stmt = stmt.order_by(
-            PointApplication.submitted_at.desc().nulls_last(),
-            PointApplication.updated_at.desc(),
+            *submitted_at_desc_nulls_last(
+                PointApplication.submitted_at,
+                PointApplication.updated_at.desc(),
+            )
         )
     stmt = stmt.limit(limit).offset(offset)
     apps = list(db.scalars(stmt))


### PR DESCRIPTION
## Summary
- Azure MySQL が解釈できない `ORDER BY ... NULLS LAST`（SQLAlchemy `.nulls_last()`）をやめ、`CASE` で NULL を末尾に回す方言非依存の並びに変更
- `point_applications` / `approvals` の共通ロジックは `app/query_order.py` に集約

## Test plan
- [ ] `GET /api/point-applications?tab=incomplete` が MySQL で 200
- [ ] ローカル SQLite で同エンドポイントが変わらず動く

Closes #38