### PR TITLE
fix(frontend): 因果ストーリーの高密度化と issue #40 のビューポート方針

### DIFF
--- a/frontend/src/app/cascade/page.tsx
+++ b/frontend/src/app/cascade/page.tsx
@@ -4,7 +4,7 @@ export const metadata = { title: "因果ストーリー | barhunters" };
 
 export default function CascadePage() {
   return (
-    <main className="mx-auto max-w-screen-2xl px-3 py-2">
+    <main className="mx-auto max-w-screen-2xl px-2 py-1">
       <CascadeBoard />
     </main>
   );

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,9 +2,12 @@ import { Sidebar } from "@/components/Sidebar";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen bg-white text-slate-800">
+    <div className="flex h-screen min-h-0 bg-white text-slate-800">
       <Sidebar />
-      <main className="flex flex-1 flex-col overflow-hidden bg-white">{children}</main>
+      {/* min-h-0 + overflow-y-auto: Flex 配下での縦スクロール用フォールバック（理想はコンテンツをビューポート収め、cascade で高密度化）。 */}
+      <main className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-white">
+        {children}
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/cascade/CascadeBoard.tsx
+++ b/frontend/src/components/cascade/CascadeBoard.tsx
@@ -272,20 +272,20 @@ function CascadeBoardInner() {
   const detailIndicatorMeta = detailId ? (INDICATOR_META[detailId] ?? null) : null;
 
   return (
-    <div className="flex flex-col gap-2">
-      {/* ヘッダー + スコープトグル + サマリー（1行に圧縮） */}
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-ink-secondary/20 pb-1.5">
-        <h1 className="text-[18px] font-semibold tracking-tight text-ink-primary">
+    <div className="flex flex-col gap-1">
+      {/* ヘッダー + スコープトグル + サマリー */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 border-b border-ink-secondary/20 pb-1">
+        <h1 className="text-[16px] font-semibold tracking-tight text-ink-primary">
           因果ストーリー
         </h1>
-        <div className="flex gap-4 text-[13px]">
+        <div className="flex gap-3 text-[12px]">
           {SCOPE_OPTIONS.map((s) => (
             <button
               key={s.key}
               type="button"
               onClick={() => setScope(s.key)}
               className={cn(
-                "-mb-1.5 border-b-2 pb-1.5 transition-colors",
+                "-mb-1 border-b-2 pb-1 transition-colors",
                 scope === s.key
                   ? "border-brand-primary font-semibold text-ink-primary"
                   : "border-transparent text-ink-secondary hover:text-ink-primary",
@@ -295,7 +295,7 @@ function CascadeBoardInner() {
             </button>
           ))}
         </div>
-        <div className="ml-auto flex items-center gap-2 text-[13px] text-ink-secondary">
+        <div className="ml-auto flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px] text-ink-secondary">
           <span className="font-semibold text-ink-primary">合計</span>
           <span className="tabular-nums text-ink-primary">
             {total.toLocaleString()} pt
@@ -308,14 +308,14 @@ function CascadeBoardInner() {
           <button
             type="button"
             onClick={handleSample}
-            className="ml-2 rounded-md border border-ink-secondary/30 bg-card px-2 py-0.5 text-ink-primary hover:bg-brand-bg-light"
+            className="ml-2 rounded border border-ink-secondary/30 bg-card px-1.5 py-px text-[11px] text-ink-primary hover:bg-brand-bg-light"
           >
             目標値プリセット
           </button>
           <button
             type="button"
             onClick={handleReset}
-            className="rounded-md border border-ink-secondary/30 bg-card px-2 py-0.5 text-ink-primary hover:bg-brand-bg-light"
+            className="rounded border border-ink-secondary/30 bg-card px-1.5 py-px text-[11px] text-ink-primary hover:bg-brand-bg-light"
           >
             リセット
           </button>
@@ -504,7 +504,7 @@ function CascadeGrid({
   return (
     <div
       ref={containerRef}
-      className="relative grid grid-cols-1 gap-6 lg:grid-cols-[1.1fr_0.9fr_1fr_1fr_1fr]"
+      className="relative grid grid-cols-1 gap-3 lg:grid-cols-[1.05fr_0.85fr_0.92fr_0.92fr_0.92fr]"
     >
       {children}
       <ArrowOverlay edges={connections} activeId={activeId} />
@@ -536,19 +536,19 @@ function Column({
   return (
     <section
       className={cn(
-        "flex min-w-0 flex-col gap-1.5 rounded-xl border p-1.5",
+        "flex min-w-0 flex-col gap-1 rounded-lg border px-1 py-1",
         toneClass,
       )}
     >
-      <header className="flex items-baseline gap-2 px-1">
-        <h2 className="text-[15px] font-normal leading-none tracking-normal text-ink-primary">
+      <header className="flex items-baseline gap-1.5 px-0.5">
+        <h2 className="text-[12px] font-medium leading-none tracking-normal text-ink-primary">
           {title}
         </h2>
         {subtitle ? (
           <span className="text-[11px] text-ink-secondary">{subtitle}</span>
         ) : null}
       </header>
-      <div className="flex flex-col gap-1.5">{children}</div>
+      <div className="flex flex-col gap-1">{children}</div>
     </section>
   );
 }

--- a/frontend/src/components/cascade/IndicatorCard.tsx
+++ b/frontend/src/components/cascade/IndicatorCard.tsx
@@ -78,7 +78,7 @@ function ReliabilityStars({ reliability }: { reliability: Reliability }) {
   const filled = reliability.length;
   const empty = 3 - filled;
   return (
-    <span className="text-[12px] leading-none text-brand-accent">
+    <span className="text-[10px] leading-none text-brand-accent">
       {"★".repeat(filled)}
       {"☆".repeat(empty)}
     </span>
@@ -131,7 +131,7 @@ export function IndicatorCard({
       className={cn(
         "group relative w-full rounded-lg border border-transparent bg-card text-left shadow-sm transition-all duration-150",
         "hover:shadow-md",
-        isMain ? "p-3" : "p-2",
+        isMain ? "p-2" : "p-1.5",
         isMain && "border-brand-primary/40 bg-brand-bg-light",
         inChain && "ring-2 ring-brand-primary ring-offset-1 bg-brand-bg-light",
         dimmed && "opacity-40",
@@ -140,7 +140,7 @@ export function IndicatorCard({
       <div className="flex items-start justify-between gap-1.5">
         <span
           className={cn(
-            "truncate text-[13px] font-medium leading-tight",
+            "truncate text-[12px] font-medium leading-tight",
             isMain ? "text-brand-primary" : "text-ink-primary",
           )}
         >
@@ -167,7 +167,7 @@ export function IndicatorCard({
             }}
             className="inline-flex cursor-pointer items-center rounded p-0.5 text-ink-secondary hover:bg-brand-bg-light hover:text-ink-primary"
           >
-            <Search className="h-3.5 w-3.5" />
+            <Search className="h-3 w-3" />
           </span>
         </div>
       </div>
@@ -177,7 +177,7 @@ export function IndicatorCard({
           <div
             className={cn(
               "leading-tight text-ink-primary",
-              isMain ? "text-base" : "text-[12px]",
+              isMain ? "text-[13px]" : "text-[11px]",
             )}
           >
             {qualitativeCurrent ? (
@@ -193,13 +193,13 @@ export function IndicatorCard({
             <div
               className={cn(
                 "font-bold tabular-nums leading-tight",
-                isMain ? "text-2xl text-brand-primary" : "text-[18px] text-ink-primary",
+                isMain ? "text-xl text-brand-primary" : "text-[15px] text-ink-primary",
               )}
             >
               <span className="transition-all duration-300 ease-out">
                 {formatNum(value, unit)}
               </span>
-              <span className="mx-1.5 text-sm font-normal text-ink-secondary">
+              <span className="mx-1 text-xs font-normal text-ink-secondary">
                 →
               </span>
               <span>{formatNum(target, unit)}</span>
@@ -207,14 +207,14 @@ export function IndicatorCard({
             {delta !== null && delta !== 0 ? (
               <div
                 className={cn(
-                  "mt-0.5 text-[11px] tabular-nums",
+                  "mt-0 text-[10px] tabular-nums",
                   delta > 0 ? "text-status-ok-fg" : "text-status-ng-fg",
                 )}
               >
                 {deltaText(delta, unit)}
               </div>
             ) : delta === 0 ? (
-              <div className="mt-0.5 text-[11px] tabular-nums text-ink-secondary">
+              <div className="mt-0 text-[10px] tabular-nums text-ink-secondary">
                 目標達成
               </div>
             ) : null}
@@ -224,7 +224,7 @@ export function IndicatorCard({
             <div
               className={cn(
                 "font-bold tabular-nums leading-tight",
-                isMain ? "text-2xl text-brand-primary" : "text-[18px] text-ink-primary",
+                isMain ? "text-xl text-brand-primary" : "text-[15px] text-ink-primary",
               )}
             >
               {formatNum(target, unit)}
@@ -239,16 +239,16 @@ export function IndicatorCard({
             </span>
           </div>
         ) : description ? (
-          <div className="line-clamp-2 text-[11px] leading-snug text-ink-secondary">
+          <div className="line-clamp-1 text-[10px] leading-snug text-ink-secondary">
             {description}
           </div>
         ) : (
-          <div className="text-base text-ink-secondary">—</div>
+          <div className="text-sm text-ink-secondary">—</div>
         )}
       </div>
 
       {isMain && description ? (
-        <div className="mt-1 line-clamp-2 text-[10px] text-ink-secondary">
+        <div className="mt-0.5 line-clamp-1 text-[9px] text-ink-secondary">
           {description}
         </div>
       ) : null}

--- a/frontend/src/components/cascade/InputGrid.tsx
+++ b/frontend/src/components/cascade/InputGrid.tsx
@@ -37,7 +37,7 @@ export function InputGrid({
   onHoverLeave,
 }: Props) {
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-1">
       {CELL_KEYS.map((key) => {
         const isActive = activeId === key;
         const inChain = isActive || highlighted.has(key);
@@ -95,7 +95,7 @@ function CellButton({
       onFocus={() => onHoverEnter(cellKey)}
       onBlur={onHoverLeave}
       className={cn(
-        "group relative rounded-lg border border-transparent bg-card p-2 text-left shadow-sm transition-all duration-150",
+        "group relative rounded-lg border border-transparent bg-card p-1.5 text-left shadow-sm transition-all duration-150",
         "hover:shadow-md",
         (isSelected || isHighlighted) &&
           "ring-2 ring-brand-primary ring-offset-1 bg-brand-bg-light",
@@ -106,8 +106,8 @@ function CellButton({
         className={cn("absolute left-0 top-0 h-full w-1 rounded-l-lg", CAT_DOT[cat])}
         aria-hidden
       />
-      <div className="flex items-center gap-2 pl-2">
-        <span className="flex-1 truncate text-[13px] font-medium text-ink-primary">
+      <div className="flex items-center gap-1.5 pl-1.5">
+        <span className="flex-1 truncate text-[12px] font-medium text-ink-primary">
           {CELL_LABEL[cellKey]}
         </span>
         <Input
@@ -118,9 +118,9 @@ function CellButton({
           placeholder="0"
           onClick={(e) => e.stopPropagation()}
           onChange={(e) => onChange(cellKey, Math.max(0, Number(e.target.value) || 0))}
-          className="h-7 w-20 px-1.5 text-right text-sm font-bold tabular-nums focus-visible:ring-brand-primary"
+          className="h-6 w-[4.5rem] px-1 text-right text-xs font-bold tabular-nums focus-visible:ring-brand-primary"
         />
-        <span className="text-[11px] font-semibold text-ink-secondary">pt</span>
+        <span className="text-[10px] font-semibold text-ink-secondary">pt</span>
       </div>
     </button>
   );

--- a/frontend/src/components/cascade/PlaceholderCard.tsx
+++ b/frontend/src/components/cascade/PlaceholderCard.tsx
@@ -6,14 +6,14 @@ export function PlaceholderCard({ label, hint }: { label: string; hint?: string 
   return (
     <div
       className={cn(
-        "rounded-lg border border-dashed border-ink-secondary/30 bg-brand-bg-light/40 p-2 text-left",
+        "rounded-lg border border-dashed border-ink-secondary/30 bg-brand-bg-light/40 p-1.5 text-left",
       )}
     >
-      <div className="truncate text-[13px] font-medium text-ink-secondary">{label}</div>
-      <div className="mt-0.5 flex items-baseline justify-between gap-2">
-        <div className="text-base font-semibold text-ink-secondary">—</div>
+      <div className="truncate text-[11px] font-medium text-ink-secondary">{label}</div>
+      <div className="mt-px flex items-baseline justify-between gap-2">
+        <div className="text-sm font-semibold text-ink-secondary">—</div>
         {hint ? (
-          <span className="text-[11px] text-ink-secondary/80">{hint}</span>
+          <span className="text-[10px] text-ink-secondary/80">{hint}</span>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## 概要

Issue #40 対応。因果ストーリーは **一覧を縦に延ばしてページスクロールに頼る設計を避ける**方針のもと、レイアウトを高密度化する。

## 変更内容

- **`AppShell`**: 親を `min-h-0`、コンテンツ `main` を `min-h-0 overflow-y-auto`（ごく狭い画面での溢出のみ縦スクロール可）
- **`CascadeBoard`**: ヘッダー／列コンテナ／グリッドギャップの縮小
- **`IndicatorCard` / `InputGrid` / `PlaceholderCard`**: パディング・フォント・行間を削減
- **`app/cascade/page.tsx`**: ページ周りのパディングを軽量化

## 動作確認

- `/cascade` でボード全体の縦長さが従来より収まりやすいこと

Closes #40