### PR TITLE
feat: マイページと部署ジャンル別ポイント内訳

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,9 +1,10 @@
 """ダッシュボード API（PR-B）。
 
-3 つの集計エンドポイントを提供：
+4 つの集計エンドポイントを提供：
   - GET /api/dashboard/active-rate    : アクティブ率（rate / mom / vs_company）
   - GET /api/dashboard/oneonone        : 1on1 件数（pair_type 別 + 合計）
   - GET /api/dashboard/points-summary  : 合計ポイント + 年間目標
+  - GET /api/dashboard/member-points-by-genre : 課長・部長向けジャンル別（自 org）
 
 クエリパラメータ共通：
   company    : "HD" | "SAIBU"（MVP では DB 絞り込みに使わない）
@@ -22,9 +23,12 @@ from sqlalchemy.orm import Session
 from app.auth import get_current_user
 from app.db import get_db
 from app.models import User
+from app.schemas.points_breakdown import OrgMemberGenrePointsRowOut, OrgMemberPointsByGenreOut
 from app.services import dashboard_service
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
+
+MANAGER_MEMBER_POINTS_ROLES = frozenset({"課長", "部長"})
 
 
 def _validated_fy(fy: str) -> str:
@@ -91,4 +95,37 @@ def get_points_summary(
     dept_name = dept_list[0] if len(dept_list) == 1 else None
     return dashboard_service.aggregate_points_summary(
         db, org_ids, fy, month, dept_name=dept_name
+    )
+
+
+@router.get("/member-points-by-genre", response_model=OrgMemberPointsByGenreOut)
+def get_member_points_by_genre_for_my_org(
+    fy: str = Query("FY2026"),
+    month: int = Query(5, ge=1, le=12),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OrgMemberPointsByGenreOut:
+    """課長・部長のみ: 自分の所属 org メンバーのジャンル別ポイント（一覧表 UI 向けフラット行）。"""
+    if current_user.role not in MANAGER_MEMBER_POINTS_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この一覧は課長・部長のみ利用できます",
+        )
+    if not current_user.org_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="所属部署が未設定のため集計できません",
+        )
+
+    fy = _validated_fy(fy)
+    rows_raw = dashboard_service.aggregate_org_member_points_by_genre(
+        db,
+        org_id=current_user.org_id,
+        fy=fy,
+        month=month,
+    )
+    return OrgMemberPointsByGenreOut(
+        fy=fy,
+        month=month,
+        rows=[OrgMemberGenrePointsRowOut.model_validate(r) for r in rows_raw],
     )

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -10,6 +10,8 @@ from app.auth import get_current_user
 from app.db import get_db
 from app.models import User
 from app.schemas.master import ApprovalRouteOut, UserBriefOut
+from app.schemas.points_breakdown import GenrePointsRowOut, MyPointsByGenreOut
+from app.services import dashboard_service
 
 router = APIRouter(prefix="/api/users", tags=["users"])
 
@@ -34,6 +36,32 @@ def list_users(db: Session = Depends(get_db)) -> list[UserBriefOut]:
 def get_me(current_user: User = Depends(get_current_user)) -> UserBriefOut:
     """現在のログインユーザーを返す（サイドバー左下の表示用）。"""
     return UserBriefOut.model_validate(current_user)
+
+
+@router.get("/me/points-by-genre", response_model=MyPointsByGenreOut)
+def get_my_points_by_genre(
+    fy: str = Query("FY2026"),
+    month: int = Query(5, ge=1, le=12),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> MyPointsByGenreOut:
+    """自分の承認済みポイントを活動ジャンル別に返す（ダッシュボードと同 FY 累積期間）。"""
+    try:
+        fy_n = dashboard_service.normalize_fy(fy)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    agg = dashboard_service.aggregate_my_points_by_genre(
+        db,
+        user_id=current_user.id,
+        fy=fy_n,
+        month=month,
+    )
+    return MyPointsByGenreOut(
+        fy=fy_n,
+        month=month,
+        rows=[GenrePointsRowOut.model_validate(r) for r in agg["rows"]],
+        total_points=agg["total_points"],
+    )
 
 
 @router.get("/approval-route", response_model=ApprovalRouteOut)

--- a/backend/app/schemas/points_breakdown.py
+++ b/backend/app/schemas/points_breakdown.py
@@ -1,0 +1,34 @@
+"""ポイントジャンル内訳 API のレスポンススキーマ。"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GenrePointsRowOut(BaseModel):
+    activity_genre_id: int
+    activity_genre_name: str
+    sort_order: int
+    points: int
+
+
+class MyPointsByGenreOut(BaseModel):
+    fy: str
+    month: int
+    rows: list[GenrePointsRowOut]
+    total_points: int
+
+
+class OrgMemberGenrePointsRowOut(BaseModel):
+    applicant_user_id: str
+    applicant_name: str
+    activity_genre_id: int
+    activity_genre_name: str
+    genre_sort_order: int
+    points: int
+
+
+class OrgMemberPointsByGenreOut(BaseModel):
+    fy: str
+    month: int
+    rows: list[OrgMemberGenrePointsRowOut]

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -1,9 +1,11 @@
 """ダッシュボード集計サービス（PR-B）。
 
-3 つのカード分の集計関数を提供する：
+カードおよびポイントジャンル内訳の集計関数：
   - aggregate_active_rate   : アクティブ率（累積モデル）
   - aggregate_one_on_one    : 1on1 件数（pair_type 別）
   - aggregate_points_summary: 合計ポイント + 年間目標
+  - aggregate_my_points_by_genre         : マイページ（自分×ジャンル）
+  - aggregate_org_member_points_by_genre : 課長・部長向け（部署メンバー×ジャンル）
 
 設計メモ：
 - 期間は「FY 頭（4/1）〜 選択月末」の累積。前月比は同 FY 内の前月との差。
@@ -23,7 +25,7 @@ from datetime import date, timedelta
 from sqlalchemy import distinct, func, select
 from sqlalchemy.orm import Session
 
-from app.models import OneOnOne, Organization, PointApplication, User
+from app.models import ActivityGenre, OneOnOne, Organization, PointApplication, User
 
 # 部署別の年間目標値（P）。未登録の部署は "default" を使う。
 ANNUAL_TARGETS: dict[str, int] = {
@@ -232,3 +234,112 @@ def aggregate_points_summary(
     )
 
     return {"total": int(total), "annual_target": annual_target}
+
+
+# ════════════════════════════════════════════════════════════
+# ジャンル別ポイント（マイページ・マネージャー向け表）
+# ════════════════════════════════════════════════════════════
+
+
+def _approved_period_bounds(fy: str, month: int) -> tuple[date, date]:
+    """承認済み申請の期間フィルタ用。(start_day, end_exclusive_next_day)。"""
+    start, end = period_from_fy_month(fy, month)
+    end_exclusive = end + timedelta(days=1)
+    return start, end_exclusive
+
+
+def aggregate_my_points_by_genre(
+    session: Session,
+    *,
+    user_id: str,
+    fy: str,
+    month: int,
+) -> dict:
+    """承認済み申請を FY 累積期間で activity_genre 別に合計（ジャンル未設定は対象外）。"""
+    start, end_exclusive = _approved_period_bounds(fy, month)
+    stmt = (
+        select(
+            ActivityGenre.id,
+            ActivityGenre.name,
+            ActivityGenre.sort_order,
+            func.coalesce(func.sum(PointApplication.points), 0).label("pts"),
+        )
+        .join(ActivityGenre, ActivityGenre.id == PointApplication.activity_genre_id)
+        .where(
+            PointApplication.applicant_user_id == user_id,
+            PointApplication.status == "approved",
+            PointApplication.decided_at.is_not(None),
+            PointApplication.decided_at >= start,
+            PointApplication.decided_at < end_exclusive,
+        )
+        .group_by(ActivityGenre.id, ActivityGenre.name, ActivityGenre.sort_order)
+        .order_by(ActivityGenre.sort_order, ActivityGenre.id)
+    )
+    rows_raw = session.execute(stmt).all()
+    rows = [
+        {
+            "activity_genre_id": int(gid),
+            "activity_genre_name": str(gname),
+            "sort_order": int(sort_order),
+            "points": int(pts),
+        }
+        for gid, gname, sort_order, pts in rows_raw
+        if int(pts) != 0
+    ]
+    total = sum(r["points"] for r in rows)
+    return {"rows": rows, "total_points": total}
+
+
+def aggregate_org_member_points_by_genre(
+    session: Session,
+    *,
+    org_id: str,
+    fy: str,
+    month: int,
+) -> list[dict]:
+    """所属 org のメンバーについて、ジャンル別の承認済みポイント行を返す。"""
+    start, end_exclusive = _approved_period_bounds(fy, month)
+    stmt = (
+        select(
+            User.id,
+            User.name,
+            ActivityGenre.id,
+            ActivityGenre.name,
+            ActivityGenre.sort_order,
+            func.coalesce(func.sum(PointApplication.points), 0).label("pts"),
+        )
+        .select_from(User)
+        .join(PointApplication, PointApplication.applicant_user_id == User.id)
+        .join(ActivityGenre, ActivityGenre.id == PointApplication.activity_genre_id)
+        .where(
+            User.org_id == org_id,
+            PointApplication.status == "approved",
+            PointApplication.decided_at.is_not(None),
+            PointApplication.decided_at >= start,
+            PointApplication.decided_at < end_exclusive,
+        )
+        .group_by(
+            User.id,
+            User.name,
+            ActivityGenre.id,
+            ActivityGenre.name,
+            ActivityGenre.sort_order,
+        )
+        .order_by(User.name, ActivityGenre.sort_order, ActivityGenre.id)
+    )
+    out: list[dict] = []
+    for uid, uname, gid, gname, sort_order, pts in session.execute(stmt).all():
+        p = int(pts)
+        if p == 0:
+            continue
+        out.append(
+            {
+                "applicant_user_id": str(uid),
+                "applicant_name": str(uname),
+                "activity_genre_id": int(gid),
+                "activity_genre_name": str(gname),
+                "genre_sort_order": int(sort_order),
+                "points": p,
+            }
+        )
+    return out

--- a/frontend/src/app/dashboard/pageClient.tsx
+++ b/frontend/src/app/dashboard/pageClient.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { PageHeader } from "@/components/PageHeader";
 import { ActiveRateCard } from "@/components/dashboard/ActiveRateCard";
 import { ActivityMatrixCard } from "@/components/dashboard/ActivityMatrixCard";
 import { FilterPanel } from "@/components/dashboard/FilterPanel";
+import { MemberPointsByGenreSection } from "@/components/dashboard/MemberPointsByGenreSection";
 import { OneOnOneCard } from "@/components/dashboard/OneOnOneCard";
 import { TotalPointsCard } from "@/components/dashboard/TotalPointsCard";
+import { PageHeader } from "@/components/PageHeader";
+import { apiFetch } from "@/lib/api";
+import type { UserBrief } from "@/lib/api/types";
 import { computeDashboardData } from "@/lib/dashboard/mockData";
 import type { DashboardFilter } from "@/lib/dashboard/types";
+
+function isManagerLikeRole(role: string | null | undefined): boolean {
+  return role === "課長" || role === "部長";
+}
 
 export function DashboardPageClient() {
   const [filter, setFilter] = useState<DashboardFilter>({
@@ -21,18 +28,34 @@ export function DashboardPageClient() {
     month: 5,
   });
 
+  const [me, setMe] = useState<UserBrief | null>(null);
+
+  useEffect(() => {
+    apiFetch<UserBrief>("/api/users/me")
+      .then(setMe)
+      .catch(() => setMe(null));
+  }, []);
+
   const data = useMemo(() => computeDashboardData(filter), [filter]);
+  const showMemberPoints = isManagerLikeRole(me?.role);
 
   return (
     <div className="flex h-full flex-col">
       <PageHeader title="ダッシュボード" />
-      <div className="flex-1 min-h-0 overflow-hidden bg-[#faf8f5] px-6 pb-4 pt-2">
-        <div className="grid h-full grid-cols-[1fr_220px] gap-2">
-          <div className="grid grid-cols-2 grid-rows-2 gap-2">
-            <ActiveRateCard data={data} />
-            <OneOnOneCard data={data} />
-            <ActivityMatrixCard data={data} />
-            <TotalPointsCard total={data.totalPoints} annualTarget={data.annualTarget} />
+      <div className="min-h-0 flex-1 overflow-hidden bg-[#faf8f5] px-6 pb-4 pt-2">
+        <div className="grid h-full min-h-0 grid-cols-[1fr_220px] gap-2">
+          <div className="flex min-h-0 flex-col gap-2 overflow-hidden">
+            <div className="grid min-h-0 shrink-0 grid-cols-2 grid-rows-2 gap-2">
+              <ActiveRateCard data={data} />
+              <OneOnOneCard data={data} />
+              <ActivityMatrixCard data={data} />
+              <TotalPointsCard total={data.totalPoints} annualTarget={data.annualTarget} />
+            </div>
+            {showMemberPoints ? (
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <MemberPointsByGenreSection fyLabel={filter.fiscalYear} month={filter.month} />
+              </div>
+            ) : null}
           </div>
           <FilterPanel filter={filter} onChange={setFilter} />
         </div>

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react";
+
+import { MyPageClient } from "./pageClient";
+
+export const metadata = {
+  title: "マイページ | barhunters",
+};
+
+export default function MyPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full flex-col">
+          <div className="h-20 bg-[#faf8f5]" />
+          <div className="flex-1 px-8 py-6 text-sm text-slate-500">読み込み中...</div>
+        </div>
+      }
+    >
+      <MyPageClient />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/mypage/pageClient.tsx
+++ b/frontend/src/app/mypage/pageClient.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { PageHeader } from "@/components/PageHeader";
+import { ApiError } from "@/lib/api";
+import { fetchMyPointsByGenre } from "@/lib/api/pointsBreakdown";
+import type { MyPointsByGenreResponse } from "@/lib/api/types";
+
+function parseMonth(v: string | null): number {
+  const n = Number(v);
+  if (Number.isInteger(n) && n >= 1 && n <= 12) return n;
+  return 5;
+}
+
+export function MyPageClient() {
+  const router = useRouter();
+  const sp = useSearchParams();
+
+  const fy = sp.get("fy") ?? "FY2026";
+  const month = parseMonth(sp.get("month"));
+
+  const [data, setData] = useState<MyPointsByGenreResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMyPointsByGenre(fy, month)
+      .then((d) => {
+        if (!cancelled) {
+          setData(d);
+          setErr(null);
+        }
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setData(null);
+          setErr(e instanceof ApiError ? `読み込みに失敗（${e.status}）` : "読み込みに失敗しました");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fy, month]);
+
+  function setPeriod(nextFy: string, nextMonth: number) {
+    const p = new URLSearchParams();
+    p.set("fy", nextFy);
+    p.set("month", String(nextMonth));
+    router.replace(`/mypage?${p.toString()}`);
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader title="マイページ" />
+
+      <div className="flex-1 bg-[#faf8f5] px-8 py-6">
+        <section className="mx-auto max-w-3xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-6 flex flex-wrap items-end gap-4">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="mp-fy">
+                年度
+              </label>
+              <select
+                id="mp-fy"
+                value={fy}
+                onChange={(e) => setPeriod(e.target.value, month)}
+                className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+              >
+                <option value="FY2024">FY2024</option>
+                <option value="FY2025">FY2025</option>
+                <option value="FY2026">FY2026</option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="mp-mon">
+                月（累計の末尾）
+              </label>
+              <select
+                id="mp-mon"
+                value={month}
+                onChange={(e) => setPeriod(fy, Number(e.target.value))}
+                className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+              >
+                {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+                  <option key={m} value={m}>
+                    {m}月
+                  </option>
+                ))}
+              </select>
+            </div>
+            <p className="text-xs text-slate-500">
+              ポイントは承認済み申請のみ。期間はダッシュボードと同様（決裁日ベース）。
+            </p>
+          </div>
+
+          {err ? <p className="text-sm text-red-600">{err}</p> : null}
+
+          {!err && data ? (
+            <>
+              <div className="mb-4 text-sm text-slate-600">
+                集計結果（{data.fy} 〜 {data.month}月末累計）
+              </div>
+              {data.rows.length === 0 ? (
+                <p className="text-sm text-slate-500">
+                  該当期間・ジャンルで承認済みのポイントはありません。
+                </p>
+              ) : (
+                <>
+                  <table className="w-full border-collapse text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-slate-200 text-slate-600">
+                        <th className="py-2 pr-4 font-medium">活動ジャンル</th>
+                        <th className="py-2 pr-4 text-right font-medium tabular-nums">ポイント</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.rows.map((r) => (
+                        <tr key={r.activity_genre_id} className="border-b border-slate-100">
+                          <td className="py-2 pr-4">{r.activity_genre_name}</td>
+                          <td className="py-2 text-right tabular-nums font-medium">
+                            {r.points.toLocaleString("ja-JP")} pt
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                    <tfoot>
+                      <tr className="font-semibold">
+                        <td className="pt-3">合計</td>
+                        <td className="pt-3 text-right tabular-nums">
+                          {data.total_points.toLocaleString("ja-JP")} pt
+                        </td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </>
+              )}
+            </>
+          ) : null}
+
+          <div className="mt-8 border-t border-slate-100 pt-4">
+            <Link href="/dashboard" className="text-sm text-[#0178C8] hover:underline">
+              ダッシュボードへ戻る
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DevUserSwitcher.tsx
+++ b/frontend/src/components/DevUserSwitcher.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
 import { apiFetch, getDevUserId, setDevUserId } from "@/lib/api";
@@ -73,6 +74,13 @@ export function DevUserSwitcher() {
           <div className="border-b border-slate-100 px-3 py-1.5 text-[10px] font-bold uppercase tracking-wide text-[#64748b]">
             開発用 ユーザー切替
           </div>
+          <Link
+            href="/mypage"
+            className="block border-b border-slate-100 px-3 py-2 text-xs font-medium text-[#0178C8] hover:bg-[#ecf5fa]"
+            onClick={() => setOpen(false)}
+          >
+            マイページ（ポイント内訳）
+          </Link>
           <button
             type="button"
             onClick={() => handleSelect(null)}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ const OTHER_ITEMS: NavItem[] = [
 // 例: pathname=/applications/new のとき /applications（申請状況）は active にならず、
 // /applications/new（申請フォーム）のみ active になる。
 const ALL_HREFS: string[] = [
+  "/mypage",
   ...NAV_GROUPS.flatMap((g) => g.items.map((i) => i.href)),
   ...STANDALONE_ITEMS.map((i) => i.href),
   ...POST_STANDALONE_GROUPS.flatMap((g) => g.items.map((i) => i.href)),

--- a/frontend/src/components/dashboard/MemberPointsByGenreSection.tsx
+++ b/frontend/src/components/dashboard/MemberPointsByGenreSection.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ApiError } from "@/lib/api";
+import { fetchOrgMemberPointsByGenre } from "@/lib/api/pointsBreakdown";
+import type { OrgMemberPointsByGenreResponse } from "@/lib/api/types";
+
+type Props = { fyLabel: string; month: number };
+
+type GenreCol = { id: number; name: string; sort: number };
+
+function buildPivot(rows: OrgMemberPointsByGenreResponse["rows"]) {
+  const memberOrder: { id: string; name: string }[] = [];
+  const seenMember = new Set<string>();
+  for (const r of rows) {
+    if (!seenMember.has(r.applicant_user_id)) {
+      seenMember.add(r.applicant_user_id);
+      memberOrder.push({ id: r.applicant_user_id, name: r.applicant_name });
+    }
+  }
+  memberOrder.sort((a, b) => a.name.localeCompare(b.name, "ja"));
+
+  const genreMap = new Map<number, GenreCol>();
+  for (const r of rows) {
+    genreMap.set(r.activity_genre_id, {
+      id: r.activity_genre_id,
+      name: r.activity_genre_name,
+      sort: r.genre_sort_order,
+    });
+  }
+  const genreCols = [...genreMap.values()].sort((a, b) =>
+    a.sort !== b.sort ? a.sort - b.sort : a.id - b.id,
+  );
+
+  const cell = new Map<string, Map<number, number>>();
+  for (const r of rows) {
+    if (!cell.has(r.applicant_user_id)) {
+      cell.set(r.applicant_user_id, new Map());
+    }
+    cell.get(r.applicant_user_id)!.set(r.activity_genre_id, r.points);
+  }
+
+  const rowTotals = new Map<string, number>();
+  for (const m of memberOrder) {
+    let sum = 0;
+    for (const g of genreCols) {
+      sum += cell.get(m.id)?.get(g.id) ?? 0;
+    }
+    rowTotals.set(m.id, sum);
+  }
+
+  return { memberOrder, genreCols, cell, rowTotals };
+}
+
+export function MemberPointsByGenreSection({ fyLabel, month }: Props) {
+  const [data, setData] = useState<OrgMemberPointsByGenreResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchOrgMemberPointsByGenre(fyLabel, month)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiError && e.status === 403) {
+          setData(null);
+          setError(null);
+          return;
+        }
+        setData(null);
+        setError(
+          e instanceof ApiError
+            ? `部署別内訳の取得に失敗（${e.status}）`
+            : "部署別内訳の取得に失敗しました",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fyLabel, month]);
+
+  const pivoted = useMemo(() => {
+    if (!data || data.rows.length === 0) return null;
+    return buildPivot(data.rows);
+  }, [data]);
+
+  if (error) {
+    return (
+      <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data || data.rows.length === 0 || !pivoted) {
+    return null;
+  }
+
+  const { memberOrder, genreCols, cell, rowTotals } = pivoted;
+
+  return (
+    <section className="rounded-lg border border-black/5 bg-white p-3 shadow-sm">
+      <div className="mb-3 flex flex-wrap items-baseline gap-2 border-b border-slate-100 pb-2">
+        <h2 className="text-[14px] font-semibold text-ink-primary">部署メンバー×活動ジャンル（pt）</h2>
+        <span className="text-[11px] text-slate-500">
+          {data.fy} 〜 {data.month}月末累計／承認済みのみ／自所属のみ
+        </span>
+      </div>
+      <div className="max-h-[min(360px,50vh)] overflow-auto">
+        <table className="w-full border-collapse text-left text-[11px] text-slate-800">
+          <thead className="sticky top-0 z-[1] bg-white shadow-sm">
+            <tr className="border-b border-slate-200">
+              <th className="whitespace-nowrap py-2 pl-2 pr-3 font-medium">氏名</th>
+              {genreCols.map((g) => (
+                <th
+                  key={g.id}
+                  className="min-w-[4.5rem] whitespace-nowrap py-2 px-1 text-center font-normal text-[10px] leading-tight text-slate-600"
+                  title={g.name}
+                >
+                  {g.name}
+                </th>
+              ))}
+              <th className="py-2 pr-2 text-right font-medium tabular-nums">計</th>
+            </tr>
+          </thead>
+          <tbody>
+            {memberOrder.map((m) => (
+              <tr key={m.id} className="border-b border-slate-100">
+                <td className="whitespace-nowrap py-1.5 pl-2 pr-3">{m.name}</td>
+                {genreCols.map((g) => {
+                  const val = cell.get(m.id)?.get(g.id) ?? 0;
+                  return (
+                    <td key={g.id} className="py-1.5 text-center tabular-nums">
+                      {val > 0 ? val : "—"}
+                    </td>
+                  );
+                })}
+                <td className="py-1.5 pr-2 text-right font-medium tabular-nums">
+                  {rowTotals.get(m.id)!.toLocaleString("ja-JP")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/api/pointsBreakdown.ts
+++ b/frontend/src/lib/api/pointsBreakdown.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from "@/lib/api";
+
+import type {
+  MyPointsByGenreResponse,
+  OrgMemberPointsByGenreResponse,
+} from "@/lib/api/types";
+
+function fyMonthQuery(fy: string, month: number): string {
+  const p = new URLSearchParams({ fy, month: String(month) });
+  return `?${p.toString()}`;
+}
+
+/** 自分のジャンル別ポイント（FY 頭〜選択月末の累積、承認済のみ）。 */
+export function fetchMyPointsByGenre(fy: string, month: number) {
+  return apiFetch<MyPointsByGenreResponse>(
+    `/api/users/me/points-by-genre${fyMonthQuery(fy, month)}`,
+  );
+}
+
+/** 自分の所属 org メンバー×ジャンル（課長・部長のみ。403 は呼び出し側で処理）。 */
+export function fetchOrgMemberPointsByGenre(fy: string, month: number) {
+  return apiFetch<OrgMemberPointsByGenreResponse>(
+    `/api/dashboard/member-points-by-genre${fyMonthQuery(fy, month)}`,
+  );
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -13,6 +13,37 @@ export type UserBrief = {
   role: string | null;
 };
 
+/** GET /api/users/me/points-by-genre */
+export type GenrePointsRow = {
+  activity_genre_id: number;
+  activity_genre_name: string;
+  sort_order: number;
+  points: number;
+};
+
+export type MyPointsByGenreResponse = {
+  fy: string;
+  month: number;
+  rows: GenrePointsRow[];
+  total_points: number;
+};
+
+/** GET /api/dashboard/member-points-by-genre（課長・部長のみ） */
+export type OrgMemberGenrePointsRow = {
+  applicant_user_id: string;
+  applicant_name: string;
+  activity_genre_id: number;
+  activity_genre_name: string;
+  genre_sort_order: number;
+  points: number;
+};
+
+export type OrgMemberPointsByGenreResponse = {
+  fy: string;
+  month: number;
+  rows: OrgMemberGenrePointsRow[];
+};
+
 export type ApprovalRoute = {
   applicant_user_id: string;
   applicant_role: string | null;


### PR DESCRIPTION
## Summary

- **`GET /api/users/me/points-by-genre`**: ログインユーザーの承認済みポイントを活動ジャンル別に集計（決裁日がダッシュボードと同様の FY 頭〜選択月末の累積）。
- **`GET /api/dashboard/member-points-by-genre`**: **課長・部長のみ**、`current_user.org_id` 配下メンバー×ジャンルのフラット行（他部署をクエリで指定不可）。
- **フロント**: `/mypage` で自分のジャンル内訳。左下ドロップダウンから遷移。ダッシュボードではマネージャーロール時のみ「部署メンバー×ジャンル」テーブルを表示（フィルターの fy / month と同期）。

## Test plan

- [ ] `cd backend` で API 起動、フロントで `/mypage` を開き、ユーザー切り替えで数値が変わることを確認する。
- [ ] 課長または部長ユーザーでログインし、ダッシュボード下部の表が出ることを確認する。一般社員では表が出ないことを確認する。
- [ ] （任意）`/api/dashboard/member-points-by-genre` を一般ユーザーで叩き 403 を確認する。

## Notes

- リポジトリ全体の `npm run lint` は既存コードに `react-hooks/set-state-in-effect` 違反が残っているため、この PR で変更したファイルのみ ESLint で確認済みです。`npm run build` は成功しています。