### PR TITLE
fix(frontend): 因果ストーリーの背景・ヘッダーをダッシュボードと統一

### DIFF
--- a/frontend/src/app/cascade/page.tsx
+++ b/frontend/src/app/cascade/page.tsx
@@ -1,11 +1,7 @@
-import { CascadeBoard } from "@/components/cascade/CascadeBoard";
+import { CascadePageClient } from "./pageClient";
 
 export const metadata = { title: "因果ストーリー" };
 
 export default function CascadePage() {
-  return (
-    <main className="mx-auto max-w-screen-2xl px-2 py-1">
-      <CascadeBoard />
-    </main>
-  );
+  return <CascadePageClient />;
 }

--- a/frontend/src/app/cascade/pageClient.tsx
+++ b/frontend/src/app/cascade/pageClient.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { CascadeBoard } from "@/components/cascade/CascadeBoard";
+import { PageHeader } from "@/components/PageHeader";
+
+export function CascadePageClient() {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <PageHeader title="因果ストーリー" />
+      <div className="min-h-0 flex-1 overflow-y-auto bg-brand-bg-page px-6 pb-4 pt-2">
+        <CascadeBoard />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/cascade/CascadeBoard.tsx
+++ b/frontend/src/components/cascade/CascadeBoard.tsx
@@ -297,11 +297,8 @@ function CascadeBoardInner() {
 
   return (
     <div className="flex flex-col gap-1">
-      {/* ヘッダー + スコープトグル + サマリー */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 border-b border-ink-secondary/20 pb-1">
-        <h1 className="text-[16px] font-semibold tracking-tight text-ink-primary">
-          因果ストーリー
-        </h1>
+      {/* スコープトグル + サマリー（ページタイトルは PageHeader） */}
+      <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-0.5 border-b border-ink-secondary/20 pb-2">
         <div className="flex gap-3 text-[12px]">
           {SCOPE_OPTIONS.map((s) => (
             <button


### PR DESCRIPTION
## Summary

Closes #53

- 因果ストーリーをダッシュボードと同じ `PageHeader` + `bg-brand-bg-page` レイアウトに変更
- `CascadeBoard` 内の 16px 独自タイトルを削除（ツールバーのみ残す）

## Test plan

- [ ] `/cascade` の背景がダッシュボードと同じベージュ（#faf8f5）
- [ ] タイトルが 24px / #334155 の PageHeader 帯
- [ ] スコープ切替・ボード表示は従来どおり