### PR TITLE
fix(frontend): 承認・申請・1on1画面の背景を因果ストーリーと統一

### DIFF
--- a/frontend/src/components/applications/ApplicationStatusView.tsx
+++ b/frontend/src/components/applications/ApplicationStatusView.tsx
@@ -157,7 +157,7 @@ export function ApplicationStatusView() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <PageHeader title="ポイント申請状況">
         <SearchBox
           value={searchInput}
@@ -167,7 +167,7 @@ export function ApplicationStatusView() {
         />
       </PageHeader>
 
-      <div className="flex flex-1 flex-col overflow-hidden bg-white px-8 pb-8 pt-5">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-brand-bg-page px-6 pb-4 pt-2">
         {(error || info) && (
           <div className="mb-3 shrink-0 space-y-2">
             {error && (

--- a/frontend/src/components/applications/PointApplicationForm.tsx
+++ b/frontend/src/components/applications/PointApplicationForm.tsx
@@ -252,11 +252,11 @@ export function PointApplicationForm() {
 
   return (
     /* ページ全体: 上部にヘッダーバー（Figma 1:134 / h-80px bg-#faf8f5）+ 下にフォーム */
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <PageHeader title="ポイント申請フォーム" />
 
-      {/* フォームカードを内包するスクロール領域（Figmaの top:117 以下に相当） */}
-      <div className="flex flex-1 flex-col px-8 pb-8 pt-[37px] overflow-hidden bg-white">
+      {/* フォームカードを内包するスクロール領域（因果ストーリーと同系統のページ背景） */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-brand-bg-page px-6 pb-4 pt-2">
       {/* フォームカード: Figma準拠 bg-[#ecf5fa] / rounded-[5px] */}
       <div className="flex flex-1 flex-col rounded-[5px] border border-slate-200 bg-[#ecf5fa] shadow-sm overflow-hidden">
         {/* カードヘッダー: フォーム本体と同じ #ecf5fa の 1 枚扱い（区切りなし） */}

--- a/frontend/src/components/approvals/ApprovalView.tsx
+++ b/frontend/src/components/approvals/ApprovalView.tsx
@@ -179,7 +179,7 @@ export function ApprovalView() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <PageHeader
         title="ポイント承認"
         inline={
@@ -198,7 +198,7 @@ export function ApprovalView() {
         />
       </PageHeader>
 
-      <div className="flex flex-1 flex-col overflow-hidden bg-white px-8 pb-8 pt-5">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-brand-bg-page px-6 pb-4 pt-2">
         {(error || info) && (
           <div className="mb-3 shrink-0 space-y-2">
             {error && (

--- a/frontend/src/components/oneonone/OneOnOneForm.tsx
+++ b/frontend/src/components/oneonone/OneOnOneForm.tsx
@@ -74,9 +74,9 @@ export function OneOnOneForm() {
 
   if (!rolesLoading && partnerRoles.length === 0) {
     return (
-      <div className="flex h-full flex-col">
+      <div className="flex h-full min-h-0 flex-col">
         <PageHeader title="1on1 実施報告" />
-        <div className="flex-1 bg-white px-8 py-6">
+        <div className="min-h-0 flex-1 overflow-y-auto bg-brand-bg-page px-6 pb-4 pt-2">
           <div className="max-w-md rounded border border-slate-200 bg-[#ecf5fa] p-4 text-sm text-[#334155]">
             あなたの役職では 1on1 の記録はできません。
             <br />
@@ -88,9 +88,9 @@ export function OneOnOneForm() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <PageHeader title="1on1 実施報告" />
-      <div className="flex-1 overflow-auto bg-white px-8 py-6">
+      <div className="min-h-0 flex-1 overflow-y-auto bg-brand-bg-page px-6 pb-4 pt-2">
         <form
           onSubmit={handleSubmit}
           className="max-w-md space-y-4 rounded-[5px] border border-slate-200 bg-[#ecf5fa] p-5 shadow-sm"


### PR DESCRIPTION
## Summary

因果ストーリー（#53 / #54）と同様、PageHeader 下のコンテンツ背景を `bg-brand-bg-page` に統一。

対象:
- `/approvals` ポイント承認
- `/applications` 申請状況
- `/applications/new` 申請フォーム
- `/oneonone/new` 1on1 実施報告

Closes #57

## Test plan

- [ ] 各画面でヘッダー下がベージュ背景（#faf8f5）になり、白い帯がない
- [ ] フォームカード（#ecf5fa）・一覧カードの見た目は維持
- [ ] `npm run build` 成功