### PR TITLE
fix(cascade): 挑戦指数の 3 位を esg に変更し点線で接続

### DIFF
--- a/backend/app/services/calculator.py
+++ b/backend/app/services/calculator.py
@@ -543,8 +543,9 @@ def _layer3_kpi_to_mid_sorted() -> dict[str, list[tuple[str, float, str, str]]]:
 # 数値ロジック（LAYER3_TO_MID）には加えず、画面の線・ハイライトだけに反映する。
 # 既存ランキングと重複する mid は実装側で自動的に除外し、ユーザー指定順で末尾に追加する。
 VISUAL_FILLERS: dict[str, list[str]] = {
-    # 挑戦人財（既存: region 0.27, ltv 0.06）— ltv は重複除外 → +3 で合計 5
-    "challenge": ["safety_zero", "jcsi", "ltv", "esg"],
+    # 挑戦人財（既存: region 0.27, ltv 0.06）— 3 位は ESG評価（点線で接続）。
+    # ltv は重複除外 → 補充は esg/safety_zero/jcsi の順で +3、合計 5
+    "challenge": ["esg", "safety_zero", "jcsi", "ltv"],
     # 変革人財（既存: co2 0.15, esg 0.15, region 0.10）— region は重複除外 → +2 で合計 5
     "transform": ["safety_brand", "ltv"],
 }


### PR DESCRIPTION
挑戦人財ホバー時、係数による上位は region(0.27, 実線) と ltv(0.06, 点線) の 2 本のみで、3 位の点線が safety_zero（VISUAL_FILLERS 補充分）になっていた。 ユーザー要望に従い、3 位を esg に変更して点線で接続する。

VISUAL_FILLERS["challenge"] の補充順序を変更（safety_zero → esg を先頭に）:
  region (1位, 実線) / ltv (2位, 点線) / esg (3位, 点線)
  safety_zero (4位, 青枠のみ) / jcsi (5位, 青枠のみ)

数値ロジックには無影響、見た目だけの調整。
sales_effect 13.30 億 / ROIC +0.205pt / ROE +0.674pt は不変。